### PR TITLE
Fixes "Run the last map again"

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -70,6 +70,7 @@ export function registerCommands(client: LanguageClient): vscode.Disposable {
 				'wc3path': wc3path
 			}]
 		};
+		_lastMapConfig = mappath
 		return client.sendRequest(ExecuteCommandRequest.type, request)
 	};
 


### PR DESCRIPTION
It appears the line that sets the variable "_lastMapConfig" was removed in an older commit making the command not function as intended. This just adds back and sets the "_lastMapConfig" variable on successful runs of the startMap command.