### PR TITLE
Polish preview accessibility and UX

### DIFF
--- a/src/features/blpPreview.ts
+++ b/src/features/blpPreview.ts
@@ -583,7 +583,7 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
           <canvas id="canvas3d" class="stage-canvas" width="1" height="1" style="display:none;"></canvas>
         </div>
         <canvas id="gizmo" class="gizmo" width="80" height="80"></canvas>
-        <div id="loadingOverlay" class="wv-loading-overlay visible">
+        <div id="loadingOverlay" class="wv-loading-overlay visible" role="status" aria-live="polite" aria-busy="true">
           <div class="wv-spinner"></div>
           <div id="loadingText" class="wv-loading-text">Loading...</div>
         </div>
@@ -644,10 +644,12 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
       if (text) loadingText.textContent = text;
       if (isLoading) {
         overlay.classList.add('visible');
+        overlay.setAttribute('aria-busy', 'true');
         stage.classList.add('loading-stage');
         debug('loading on: ' + (text || ''));
       } else {
         overlay.classList.remove('visible');
+        overlay.setAttribute('aria-busy', 'false');
         stage.classList.remove('loading-stage');
         debug('loading off');
       }

--- a/src/features/blpPreview.ts
+++ b/src/features/blpPreview.ts
@@ -583,7 +583,7 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
           <canvas id="canvas3d" class="stage-canvas" width="1" height="1" style="display:none;"></canvas>
         </div>
         <canvas id="gizmo" class="gizmo" width="80" height="80"></canvas>
-        <div id="loadingOverlay" class="wv-loading-overlay visible" role="status" aria-live="polite" aria-busy="true">
+        <div id="loadingOverlay" class="wv-loading-overlay visible" role="status" aria-live="polite" aria-busy="true" aria-hidden="false">
           <div class="wv-spinner"></div>
           <div id="loadingText" class="wv-loading-text">Loading...</div>
         </div>
@@ -645,11 +645,13 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
       if (isLoading) {
         overlay.classList.add('visible');
         overlay.setAttribute('aria-busy', 'true');
+        overlay.setAttribute('aria-hidden', 'false');
         stage.classList.add('loading-stage');
         debug('loading on: ' + (text || ''));
       } else {
         overlay.classList.remove('visible');
         overlay.setAttribute('aria-busy', 'false');
+        overlay.setAttribute('aria-hidden', 'true');
         stage.classList.remove('loading-stage');
         debug('loading off');
       }

--- a/src/features/mpqViewer.ts
+++ b/src/features/mpqViewer.ts
@@ -322,6 +322,12 @@ function buildHtml(webview: vscode.Webview, archiveName: string, scriptUri: vsco
 }
 .row:hover { background: var(--hover); }
 .row:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
+.row-select {
+  flex: 1; min-width: 0; display: flex; align-items: center; gap: 5px;
+  padding: 0; border: 0; background: transparent; color: inherit; font: inherit;
+  text-align: left; cursor: pointer; user-select: none;
+}
+.row-select:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
 .row.selected { background: var(--active); color: var(--active-fg); }
 .row.selected .size, .row.selected .folder-meta { color: var(--active-fg); opacity: 0.75; }
 .row.hidden,

--- a/src/features/mpqViewer.ts
+++ b/src/features/mpqViewer.ts
@@ -321,6 +321,7 @@ function buildHtml(webview: vscode.Webview, archiveName: string, scriptUri: vsco
   position: relative;
 }
 .row:hover { background: var(--hover); }
+.row:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
 .row.selected { background: var(--active); color: var(--active-fg); }
 .row.selected .size, .row.selected .folder-meta { color: var(--active-fg); opacity: 0.75; }
 .row.hidden,
@@ -403,7 +404,8 @@ function buildHtml(webview: vscode.Webview, archiveName: string, scriptUri: vsco
 .row-action svg { width: 13px; height: 13px; fill: currentColor; }
 .row-action span { line-height: 1; }
 .row:hover .row-action,
-.row.selected .row-action {
+.row.selected .row-action,
+.row:focus-within .row-action {
   opacity: 0.92;
   pointer-events: auto;
 }
@@ -470,11 +472,11 @@ body.extracting .tree-wrap { cursor: progress; }
   <svg class="search-icon" width="14" height="14" viewBox="0 0 16 16" fill="var(--icon-fg)">
     <path d="M6.5 1a5.5 5.5 0 0 1 4.38 8.82l3.15 3.15-.71.71-3.15-3.15A5.5 5.5 0 1 1 6.5 1zm0 1a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9z"/>
   </svg>
-  <input class="search-input" id="searchInput" type="text" placeholder="Filter files\u2026" autocomplete="off" spellcheck="false">
+  <input class="search-input" id="searchInput" type="search" placeholder="Filter files\u2026" aria-label="Filter archive files" autocomplete="off" spellcheck="false">
   <span class="match-count" id="matchCount"></span>
 </div>
 
-<div class="tree-wrap" id="treeWrap">
+<div class="tree-wrap" id="treeWrap" role="group" aria-label="Archive contents">
   <div class="wv-state"><span>Loading archive\u2026</span></div>
 </div>
 

--- a/src/features/objModPreview.ts
+++ b/src/features/objModPreview.ts
@@ -1596,7 +1596,7 @@ function buildObjLoadingHtml(fileName: string): string {
     return buildPage({
         csp: "default-src 'none'; style-src 'unsafe-inline';",
         title: escapeHtml(fileName),
-        body: `<div class="wv-state"><div class="wv-spinner"></div><div class="wv-loading-text">Loading ${escapeHtml(fileName)}…</div></div>`,
+        body: `<div class="wv-state" role="status" aria-live="polite" aria-busy="true"><div class="wv-spinner"></div><div class="wv-loading-text">Loading ${escapeHtml(fileName)}…</div></div>`,
     });
 }
 
@@ -1641,7 +1641,7 @@ async function buildHtml(
     const metaLine = `WC3 ${typeLabel} object data - v${parsed.version} - ${summary} - ${metadataSource}` +
         `${parsed.extended ? ' - extended (level/dataPt)' : ''}${combinedMeta}`;
     const errorBanner = parsed.error
-        ? `<div class="error">Parse error: ${escapeHtml(parsed.error)}</div>`
+        ? `<div class="error" role="alert">Parse error: ${escapeHtml(parsed.error)}</div>`
         : '';
     const warningBanner = wtsWarning
         ? `<div class="warning">${escapeHtml(wtsWarning)}</div>`
@@ -2228,6 +2228,10 @@ textarea.edit-raw { min-height: 48px; line-height: 1.4; padding: 4px 6px; resize
   background: rgba(0,0,0,0.5);
 }
 .ab-overlay[hidden] { display: none; }
+.ab-sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
 .ab-modal {
   display: flex;
   flex-direction: column;
@@ -2315,8 +2319,13 @@ textarea.edit-raw { min-height: 48px; line-height: 1.4; padding: 4px 6px; resize
   border-radius: 4px;
   cursor: pointer;
   text-align: center;
+  width: 100%;
+  font: inherit;
+  color: var(--fg);
+  background: transparent;
 }
 .ab-card:hover { border-color: var(--vscode-focusBorder, #007fd4); background: var(--hover); }
+.ab-card:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
 .ab-card .object-icon { width: 48px; height: 48px; }
 .model-thumb,
 .object-icon.model-thumb { background: var(--model-bg); }
@@ -2546,6 +2555,7 @@ tr.hidden { display: none; }
 }
 .splitter:hover,
 .splitter.dragging { opacity: 1; background: var(--vscode-textLink-foreground, var(--fg)); }
+.splitter:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; opacity: 1; }
 .object-list {
   min-width: 0;
   min-height: 0;
@@ -2963,16 +2973,16 @@ ${gameDataBanner}
     </div>
     <div id="tree" class="tree"></div>
   </aside>
-  <div class="splitter" id="splitter" title="Drag to resize"></div>
+  <div class="splitter" id="splitter" role="separator" aria-orientation="vertical" aria-label="Resize object list" tabindex="0" title="Drag to resize; use arrow keys to adjust"></div>
   <main id="details" class="details"></main>
 </div>
-<div id="mpv-box" class="mpv-box" hidden>
+<div id="mpv-box" class="mpv-box" role="dialog" aria-labelledby="mpv-name" hidden>
   <div class="mpv-head" id="mpv-head">
     <span id="mpv-name" class="mpv-name">Model</span>
     <select id="mpv-anim" class="mpv-anim" title="Animation" hidden></select>
     <button id="mpv-play" class="mpv-ctl" type="button" title="Pause" aria-label="Play/pause">⏸</button>
     <button id="mpv-restart" class="mpv-ctl" type="button" title="Restart animation" aria-label="Restart">⟲</button>
-    <button id="mpv-help" class="mpv-ctl" type="button" tabindex="-1" aria-label="Controls help" title="Drag header to move · drag model to orbit · scroll to zoom · dropdown switches animation · ⟲ replays from start">?</button>
+    <button id="mpv-help" class="mpv-ctl" type="button" aria-label="Controls help" title="Drag header to move · drag model to orbit · scroll to zoom · dropdown switches animation · ⟲ replays from start">?</button>
     <button id="mpv-close" class="mpv-close" type="button" title="Close preview" aria-label="Close preview">✕</button>
   </div>
   <div id="mpv-viewport" class="mpv-viewport">
@@ -2984,21 +2994,22 @@ ${gameDataBanner}
 <canvas id="model-thumb-canvas" class="thumb-render-canvas" width="96" height="96" aria-hidden="true"></canvas>
 <div id="model-thumb-viewport" class="thumb-render-canvas" aria-hidden="true"></div>
 <div id="ab-overlay" class="ab-overlay" hidden>
-  <div class="ab-modal" role="dialog" aria-label="Asset browser">
+  <div class="ab-modal" role="dialog" aria-modal="true" aria-labelledby="ab-title">
+    <h2 id="ab-title" class="ab-sr-only">Asset browser</h2>
     <div class="ab-head">
-      <div class="ab-tabs" id="ab-tabs">
-        <button class="ab-tab" type="button" data-tab="model">Models</button>
-        <button class="ab-tab" type="button" data-tab="icon">Icons</button>
-        <button class="ab-tab" type="button" data-tab="sound">Sounds</button>
-        <button class="ab-tab" type="button" data-tab="pathing">Pathing</button>
+      <div class="ab-tabs" id="ab-tabs" role="tablist" aria-label="Asset type">
+        <button class="ab-tab" type="button" role="tab" data-tab="model" aria-controls="ab-grid" aria-selected="false">Models</button>
+        <button class="ab-tab" type="button" role="tab" data-tab="icon" aria-controls="ab-grid" aria-selected="false">Icons</button>
+        <button class="ab-tab" type="button" role="tab" data-tab="sound" aria-controls="ab-grid" aria-selected="false">Sounds</button>
+        <button class="ab-tab" type="button" role="tab" data-tab="pathing" aria-controls="ab-grid" aria-selected="false">Pathing</button>
       </div>
-      <input id="ab-search" class="ab-search" placeholder="Search game assets…" aria-label="Search assets">
+      <input id="ab-search" class="ab-search" type="search" placeholder="Search game assets…" aria-label="Search assets">
       <select id="ab-source" class="ab-source" title="Filter by source" aria-label="Filter by source">
         <option value="all">All</option>
         <option value="wc3">WC3</option>
         <option value="import">Imports</option>
       </select>
-      <span id="ab-count" class="ab-count"></span>
+      <span id="ab-count" class="ab-count" role="status" aria-live="polite"></span>
       <button id="ab-close" class="ab-close" type="button" title="Close (Esc)" aria-label="Close">✕</button>
     </div>
     <div id="ab-grid" class="ab-grid"></div>

--- a/src/features/preview/framework.ts
+++ b/src/features/preview/framework.ts
@@ -84,7 +84,7 @@ main {
   opacity: 1;
 }`,
         body: `<main>
-  <div class="wv-loading-overlay visible">
+  <div class="wv-loading-overlay visible" role="status" aria-live="polite" aria-busy="true">
     <div>
       <div class="wv-spinner"></div>
       <div class="wv-loading-text">Loading ${escapeHtml(fileName)}...</div>
@@ -98,7 +98,7 @@ function buildErrorHtml(fileName: string, message: string): string {
     return buildPage({
         csp: "default-src 'none'; style-src 'unsafe-inline';",
         title: escapeHtml(fileName),
-        body: `<div class="wv-state">
+        body: `<div class="wv-state" role="alert">
   <span>Failed to load ${escapeHtml(fileName)}</span>
   <span class="err">${escapeHtml(message)}</span>
 </div>`,

--- a/src/features/webviewShared.ts
+++ b/src/features/webviewShared.ts
@@ -321,7 +321,7 @@ export function sep(): string {
  */
 export function spinnerOverlay(textId: string, initiallyVisible = true): string {
     const cls = initiallyVisible ? 'wv-loading-overlay visible' : 'wv-loading-overlay';
-    return `<div class="${cls}">
+    return `<div class="${cls}" role="status" aria-live="polite" aria-busy="${initiallyVisible}">
   <div class="wv-spinner"></div>
   <div id="${textId}" class="wv-loading-text">Loading...</div>
 </div>`;

--- a/src/webview/mpqViewerWebview.ts
+++ b/src/webview/mpqViewerWebview.ts
@@ -290,6 +290,8 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
     };
     row.addEventListener('dblclick', openFile);
     row.addEventListener('keydown', e => {
+        // Keep the nested Open button's native keyboard activation intact.
+        if (e.target !== row) return;
         if (e.key === 'Enter') {
             e.preventDefault();
             openFile();

--- a/src/webview/mpqViewerWebview.ts
+++ b/src/webview/mpqViewerWebview.ts
@@ -163,6 +163,7 @@ const ICON_FOLDER  = '<svg viewBox="0 0 16 16"><path d="M1 4.5A1.5 1.5 0 0 1 2.5
 const ICON_OPEN    = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M8.5 1a.5.5 0 0 0-1 0v6.793L5.354 5.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 7.793V1zM3 10.5a.5.5 0 0 0-1 0v3a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-1 0V13H3v-2.5z"/></svg>';
 
 let selectedRow: HTMLElement | null = null;
+let filteredFolderState: Map<string, boolean> | null = null;
 
 function renderNode(node: TreeNode, indent: number, container: HTMLElement): void {
     if (node.type === 'folder') renderFolder(node, indent, container);
@@ -173,9 +174,14 @@ function renderFolder(node: TreeNode, indent: number, container: HTMLElement): v
     const wrapper = document.createElement('div');
     wrapper.dataset['type'] = 'folder';
     wrapper.dataset['name'] = node.name.toLowerCase();
+    wrapper.dataset['path'] = node.fullPath;
 
     const row = document.createElement('div');
     row.className = 'row';
+    row.setAttribute('role', 'button');
+    row.tabIndex = 0;
+    row.setAttribute('aria-expanded', 'false');
+    row.setAttribute('aria-label', 'Expand folder ' + node.name);
     row.style.paddingLeft = (indent * 16 + 6) + 'px';
     row.innerHTML =
         '<span class="chevron">' + ICON_CHEVRON + '</span>' +
@@ -188,9 +194,17 @@ function renderFolder(node: TreeNode, indent: number, container: HTMLElement): v
 
     for (const child of node.children) renderNode(child, indent + 1, children);
 
-    row.addEventListener('click', () => {
+    const toggleFolder = () => {
         const collapsed = wrapper.classList.toggle('collapsed');
         children.classList.toggle('collapsed', collapsed);
+        row.setAttribute('aria-expanded', String(!collapsed));
+        row.setAttribute('aria-label', (collapsed ? 'Expand' : 'Collapse') + ' folder ' + node.name);
+    };
+    row.addEventListener('click', toggleFolder);
+    row.addEventListener('keydown', e => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        toggleFolder();
     });
 
     wrapper.appendChild(row);
@@ -207,6 +221,9 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
 
     const row = document.createElement('div');
     row.className = 'row';
+    row.setAttribute('role', 'button');
+    row.tabIndex = 0;
+    row.setAttribute('aria-label', description ? `${node.fullPath} - ${description}` : node.fullPath);
     row.style.paddingLeft = (indent * 16 + 22) + 'px';
     row.dataset['type'] = 'file';
     row.dataset['fullpath'] = node.fullPath;
@@ -256,16 +273,30 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
     row.appendChild(size);
 
     // Click selects the row (does NOT immediately open)
-    row.addEventListener('click', () => {
+    const selectRow = () => {
         if (selectedRow) selectedRow.classList.remove('selected');
+        if (selectedRow) selectedRow.setAttribute('aria-pressed', 'false');
         row.classList.add('selected');
+        row.setAttribute('aria-pressed', 'true');
         selectedRow = row;
-    });
+    };
+    row.setAttribute('aria-pressed', 'false');
+    row.addEventListener('click', selectRow);
 
     // Double-click opens
-    row.addEventListener('dblclick', () => {
+    const openFile = () => {
         if (busy) return;
         vscode.postMessage({ type: 'openFile', name: node.fullPath });
+    };
+    row.addEventListener('dblclick', openFile);
+    row.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            openFile();
+        } else if (e.key === ' ') {
+            e.preventDefault();
+            selectRow();
+        }
     });
 
     container.appendChild(row);
@@ -278,11 +309,28 @@ function applyFilter(query: string): void {
     const allFiles = treeWrap.querySelectorAll<HTMLElement>('[data-type="file"]');
     let shown = 0;
 
+    if (q && !filteredFolderState) {
+        filteredFolderState = new Map<string, boolean>();
+        treeWrap.querySelectorAll<HTMLElement>('[data-type="folder"]').forEach(folder => {
+            filteredFolderState!.set(folder.dataset['path'] ?? '', !folder.classList.contains('collapsed'));
+        });
+    }
+
     if (!q) {
         allFiles.forEach(r => r.classList.remove('hidden'));
         treeWrap.querySelectorAll<HTMLElement>('[data-type="folder"]').forEach(f => f.classList.remove('hidden'));
-        treeWrap.querySelectorAll<HTMLElement>('.children').forEach(c => c.classList.add('collapsed'));
-        treeWrap.querySelectorAll<HTMLElement>('[data-type="folder"]').forEach(f => f.classList.add('collapsed'));
+        treeWrap.querySelectorAll<HTMLElement>('[data-type="folder"]').forEach(f => {
+            const expanded = filteredFolderState?.get(f.dataset['path'] ?? '') ?? false;
+            f.classList.toggle('collapsed', !expanded);
+            const children = f.querySelector<HTMLElement>(':scope > .children');
+            if (children) children.classList.toggle('collapsed', !expanded);
+            const row = f.querySelector<HTMLElement>(':scope > .row');
+            if (row) {
+                row.setAttribute('aria-expanded', String(expanded));
+                row.setAttribute('aria-label', (expanded ? 'Collapse' : 'Expand') + ' folder ' + (f.dataset['name'] ?? ''));
+            }
+        });
+        filteredFolderState = null;
         matchCount.textContent = '';
         return;
     }
@@ -301,6 +349,11 @@ function applyFilter(query: string): void {
             el.classList.remove('collapsed');
             const childrenEl = el.querySelector('.children');
             if (childrenEl) childrenEl.classList.remove('collapsed');
+            const row = el.querySelector<HTMLElement>(':scope > .row');
+            if (row) {
+                row.setAttribute('aria-expanded', 'true');
+                row.setAttribute('aria-label', 'Collapse folder ' + (el.dataset['name'] ?? ''));
+            }
         }
     }
 
@@ -355,7 +408,7 @@ window.addEventListener('message', (e: MessageEvent) => {
     }
 
     if (msg.type === 'error') {
-        treeWrap.innerHTML = '<div class="state"><span>Failed to read archive</span><span class="err">' + esc(msg.message ?? '') + '</span></div>';
+        treeWrap.innerHTML = '<div class="state" role="alert"><span>Failed to read archive</span><span class="err">' + esc(msg.message ?? '') + '</span></div>';
         btnExtractAll.setAttribute('disabled', '');
         btnExportFolder.setAttribute('disabled', '');
         return;

--- a/src/webview/mpqViewerWebview.ts
+++ b/src/webview/mpqViewerWebview.ts
@@ -221,9 +221,6 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
 
     const row = document.createElement('div');
     row.className = 'row';
-    row.setAttribute('role', 'button');
-    row.tabIndex = 0;
-    row.setAttribute('aria-label', description ? `${node.fullPath} - ${description}` : node.fullPath);
     row.style.paddingLeft = (indent * 16 + 22) + 'px';
     row.dataset['type'] = 'file';
     row.dataset['fullpath'] = node.fullPath;
@@ -256,6 +253,12 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
     size.className = 'size';
     size.textContent = fmtSize(node.entry!.normalSize);
 
+    const selectBtn = document.createElement('button');
+    selectBtn.className = 'row-select';
+    selectBtn.type = 'button';
+    selectBtn.setAttribute('aria-label', description ? `${node.fullPath} - ${description}` : node.fullPath);
+    selectBtn.setAttribute('aria-pressed', 'false');
+
     // Action button — only visible on hover/selection
     const openBtn = document.createElement('button');
     openBtn.className = 'row-action';
@@ -267,31 +270,29 @@ function renderFile(node: TreeNode, indent: number, container: HTMLElement): voi
         vscode.postMessage({ type: 'openFile', name: node.fullPath });
     });
 
-    row.appendChild(badge);
-    row.appendChild(fileMain);
+    selectBtn.appendChild(badge);
+    selectBtn.appendChild(fileMain);
+    selectBtn.appendChild(size);
+    row.appendChild(selectBtn);
     row.appendChild(openBtn);
-    row.appendChild(size);
 
     // Click selects the row (does NOT immediately open)
     const selectRow = () => {
         if (selectedRow) selectedRow.classList.remove('selected');
-        if (selectedRow) selectedRow.setAttribute('aria-pressed', 'false');
+        if (selectedRow) selectedRow.querySelector<HTMLButtonElement>('.row-select')?.setAttribute('aria-pressed', 'false');
         row.classList.add('selected');
-        row.setAttribute('aria-pressed', 'true');
+        selectBtn.setAttribute('aria-pressed', 'true');
         selectedRow = row;
     };
-    row.setAttribute('aria-pressed', 'false');
-    row.addEventListener('click', selectRow);
+    selectBtn.addEventListener('click', selectRow);
 
     // Double-click opens
     const openFile = () => {
         if (busy) return;
         vscode.postMessage({ type: 'openFile', name: node.fullPath });
     };
-    row.addEventListener('dblclick', openFile);
-    row.addEventListener('keydown', e => {
-        // Keep the nested Open button's native keyboard activation intact.
-        if (e.target !== row) return;
+    selectBtn.addEventListener('dblclick', openFile);
+    selectBtn.addEventListener('keydown', e => {
         if (e.key === 'Enter') {
             e.preventDefault();
             openFile();

--- a/src/webview/objModEditor/assetBrowser.ts
+++ b/src/webview/objModEditor/assetBrowser.ts
@@ -149,7 +149,7 @@ export function renderAssetGrid() {
   }
 }
 
-export function closeAssetBrowser() {
+export function closeAssetBrowser(restoreFocus = true) {
   assetBrowserUi.open = false;
   const ov = document.getElementById('ab-overlay');
   if (ov) ov.hidden = true;
@@ -157,15 +157,19 @@ export function closeAssetBrowser() {
   abMi = -1; // keep abCatalog cached for next time
   const returnFocus = assetBrowserReturnFocus;
   assetBrowserReturnFocus = null;
-  if (returnFocus && returnFocus.isConnected) returnFocus.focus({ preventScroll: true });
+  if (restoreFocus && returnFocus && returnFocus.isConnected) returnFocus.focus({ preventScroll: true });
+  return returnFocus;
 }
 
 export function pickAsset(value) {
   const mods = detailCache.get(ui.selectedKey) || [];
   const mi = abMi;
   const mod = mods[mi];
-  closeAssetBrowser();
-  if (!mod) return;
+  const returnFocus = closeAssetBrowser(false);
+  if (!mod) {
+    if (returnFocus && returnFocus.isConnected) returnFocus.focus({ preventScroll: true });
+    return;
+  }
   setModValue(mod, value);
   const anchor = details.querySelector('[data-mi="' + mi + '"]');
   if (anchor) markModified(anchor, mod);
@@ -174,6 +178,9 @@ export function pickAsset(value) {
   // the new pick. updateFieldCell only patches an open input's value, leaving the badge/preview stale.
   const cell = anchor ? anchor.closest('td') : null;
   if (cell) { cell._refocusOnCollapse = false; collapseCell(cell, mi); }
+  const replacement = cell?.querySelector<HTMLElement>('.tt-collapsed, .cell-edit');
+  if (replacement) replacement.focus({ preventScroll: true });
+  else if (returnFocus && returnFocus.isConnected) returnFocus.focus({ preventScroll: true });
 }
 
 export function setupAssetBrowser() {
@@ -183,7 +190,7 @@ export function setupAssetBrowser() {
   const grid = document.getElementById('ab-grid');
   const tabs = document.getElementById('ab-tabs');
   let abSearchRaf = 0;
-  if (close) close.addEventListener('click', closeAssetBrowser);
+  if (close) close.addEventListener('click', () => closeAssetBrowser());
   if (ov) ov.addEventListener('mousedown', e => { if (e.target === ov) closeAssetBrowser(); });
   if (search) search.addEventListener('input', () => {
     noteModelThumbUserActivity();

--- a/src/webview/objModEditor/assetBrowser.ts
+++ b/src/webview/objModEditor/assetBrowser.ts
@@ -253,7 +253,7 @@ export function setupAssetBrowser() {
     if (!modal) return;
     const focusable = Array.from(modal.querySelectorAll<HTMLElement>(
       'button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    )).filter(el => !el.hidden && el.offsetParent !== null);
+    )).filter(el => !el.hidden && el.offsetParent !== null && el.tabIndex >= 0);
     if (!focusable.length) {
       e.preventDefault();
       modal.focus();

--- a/src/webview/objModEditor/assetBrowser.ts
+++ b/src/webview/objModEditor/assetBrowser.ts
@@ -10,6 +10,18 @@ import type { AssetCatalog, AssetOption } from './types';
 // ── Asset browser (rich visual picker over WC3 game data, by category) ────────
 let abMi = -1;
 const abCatalog = signal<AssetCatalog | null>(null);
+let assetBrowserReturnFocus: HTMLElement | null = null;
+
+function rememberAssetBrowserFocus() {
+  if (assetBrowserUi.open) return;
+  const active = document.activeElement;
+  assetBrowserReturnFocus = active instanceof HTMLElement ? active : null;
+}
+
+function focusAssetBrowserSearch() {
+  const search = document.getElementById('ab-search') as HTMLInputElement | null;
+  if (search) search.focus();
+}
 
 export function setAssetCatalog(catalog) {
   abCatalog.value = catalog;
@@ -31,7 +43,7 @@ export function handleAssetCatalogFailed(reason) {
   if (!isAssetBrowserOpen()) return;
   const grid = document.getElementById('ab-grid');
   if (!grid) return;
-  grid.innerHTML = '<div class="ab-empty ab-error">' +
+  grid.innerHTML = '<div class="ab-empty ab-error" role="alert">' +
     '<div>Couldn\'t load game assets.</div>' +
     (reason ? '<div class="details-error-reason">' + esc(reason) + '</div>' : '') +
     '<button type="button" id="ab-catalog-retry" class="browse-btn">Retry</button>' +
@@ -42,6 +54,7 @@ export function openAssetBrowser(mi) {
   const mods = detailCache.get(ui.selectedKey) || [];
   const mod = mods[mi];
   if (!mod) return;
+  rememberAssetBrowserFocus();
   abMi = mi;
   // A model field defaults to Models; only icon/pathing fields default elsewhere — never offer the
   // wrong asset class by default.
@@ -58,6 +71,7 @@ export function openAssetBrowser(mi) {
 }
 
 export function openModelAssetBrowserForE2e() {
+  rememberAssetBrowserFocus();
   abMi = 0;
   assetBrowserUi.activeTab = 'model';
   assetBrowserUi.searchQuery = '';
@@ -69,6 +83,7 @@ export function openModelAssetBrowserForE2e() {
   assetBrowserUi.open = true;
   modelThumbEnsureInit();
   if (!abCatalog.peek()) requestAssetCatalog();
+  focusAssetBrowserSearch();
 }
 
 export function searchModelAssetBrowserForE2e(value) {
@@ -87,7 +102,12 @@ export function forceNarrowLayoutForE2e(on) {
 export function updateAbTabs() {
   const tabs = document.getElementById('ab-tabs');
   if (!tabs) return;
-  for (const b of tabs.querySelectorAll('.ab-tab')) b.classList.toggle('active', b.getAttribute('data-tab') === assetBrowserUi.activeTab);
+  for (const b of tabs.querySelectorAll<HTMLButtonElement>('.ab-tab')) {
+    const active = b.getAttribute('data-tab') === assetBrowserUi.activeTab;
+    b.classList.toggle('active', active);
+    b.setAttribute('aria-selected', String(active));
+    b.tabIndex = active ? 0 : -1;
+  }
 }
 
 export function renderAssetGrid() {
@@ -119,8 +139,8 @@ export function renderAssetGrid() {
         ? '<span class="object-icon" data-key="ab:' + esc(o.value) + '" data-icon="' + esc(o.iconPath) + '"></span>'
         : '<span class="object-icon missing"></span>');
     const previewHint = activeTab === 'model' ? ' — Ctrl+click to open full preview' : '';
-    return '<div class="ab-card" data-value="' + esc(o.value) + '" title="' + esc(o.label + ' — ' + o.value + previewHint) + '">' +
-      icon + '<span class="ab-card-label">' + esc(o.label) + '</span></div>';
+    return '<button type="button" class="ab-card" data-value="' + esc(o.value) + '" aria-label="' + esc(o.label + ' — ' + o.value) + '" title="' + esc(o.label + ' — ' + o.value + previewHint) + '">' +
+      icon + '<span class="ab-card-label">' + esc(o.label) + '</span></button>';
   }).join('');
   iconLoader.observe(grid);
   if (activeTab === 'model') {
@@ -135,6 +155,9 @@ export function closeAssetBrowser() {
   if (ov) ov.hidden = true;
   cancelAssetBrowserModelThumbs();
   abMi = -1; // keep abCatalog cached for next time
+  const returnFocus = assetBrowserReturnFocus;
+  assetBrowserReturnFocus = null;
+  if (returnFocus && returnFocus.isConnected) returnFocus.focus({ preventScroll: true });
 }
 
 export function pickAsset(value) {
@@ -179,6 +202,18 @@ export function setupAssetBrowser() {
     assetBrowserUi.activeTab = tab.getAttribute('data-tab');
     if (assetBrowserUi.activeTab === 'model') modelThumbEnsureInit();
   });
+  if (tabs) tabs.addEventListener('keydown', e => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
+    const tabList = Array.from(tabs.querySelectorAll<HTMLButtonElement>('.ab-tab'));
+    const current = tabList.indexOf(document.activeElement as HTMLButtonElement);
+    if (current < 0 || !tabList.length) return;
+    const next = e.key === 'Home' ? 0
+      : e.key === 'End' ? tabList.length - 1
+      : (current + (e.key === 'ArrowRight' ? 1 : -1) + tabList.length) % tabList.length;
+    e.preventDefault();
+    tabList[next].focus();
+    tabList[next].click();
+  });
   if (grid) grid.addEventListener('click', e => {
     if (e.target.closest('#ab-catalog-retry')) { requestAssetCatalog(); return; }
     const card = e.target.closest('.ab-card[data-value]');
@@ -200,7 +235,36 @@ export function setupAssetBrowser() {
   document.addEventListener('scroll', noteModelThumbUserActivity, { passive: true, capture: true });
   document.addEventListener('wheel', noteModelThumbUserActivity, { passive: true });
   document.addEventListener('keydown', noteModelThumbUserActivity, { passive: true });
-  document.addEventListener('keydown', e => { if (e.key === 'Escape' && ov && !ov.hidden) closeAssetBrowser(); });
+  document.addEventListener('keydown', e => {
+    if (!ov || ov.hidden) return;
+    if (e.key === 'Escape') {
+      closeAssetBrowser();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    const modal = ov.querySelector<HTMLElement>('.ab-modal');
+    if (!modal) return;
+    const focusable = Array.from(modal.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )).filter(el => !el.hidden && el.offsetParent !== null);
+    if (!focusable.length) {
+      e.preventDefault();
+      modal.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!modal.contains(document.activeElement)) {
+      e.preventDefault();
+      first.focus();
+    } else if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
   effect(() => {
     assetBrowserUi.activeTab;
     assetBrowserUi.searchQuery;

--- a/src/webview/objModEditorWebview.ts
+++ b/src/webview/objModEditorWebview.ts
@@ -105,7 +105,10 @@ function setupSplitter() {
       const rect = entries[0] && entries[0].contentRect;
       if (!rect) return;
       const next = ui.e2eForcedNarrowLayout || rect.width < NARROW_LAYOUT_PX;
-      if (next === stacked) return;
+      if (next === stacked) {
+        updateSplitterAria();
+        return;
+      }
       stacked = next;
       editor.classList.toggle('narrow', next);
       applySavedWidth();
@@ -140,9 +143,10 @@ function setupSplitter() {
   });
   splitter.addEventListener('keydown', e => {
     if (isStacked()) return;
-    const current = parseInt(editor.style.getPropertyValue('--list-w'), 10) || LIST_W_DEFAULT;
     const rect = editor.getBoundingClientRect();
     const max = Math.max(LIST_MIN_PX, rect.width * LIST_MAX_RATIO);
+    const saved = parseInt(editor.style.getPropertyValue('--list-w'), 10) || LIST_W_DEFAULT;
+    const current = Math.max(LIST_MIN_PX, Math.min(max, saved));
     let next: number | undefined;
     if (e.key === 'ArrowLeft') next = current - 16;
     else if (e.key === 'ArrowRight') next = current + 16;

--- a/src/webview/objModEditorWebview.ts
+++ b/src/webview/objModEditorWebview.ts
@@ -71,11 +71,28 @@ function setupSplitter() {
   const splitter = document.getElementById('splitter');
   if (!editor || !splitter) return;
   const isStacked = () => editor.classList.contains('narrow');
+  const updateSplitterAria = () => {
+    const rect = editor.getBoundingClientRect();
+    const max = Math.max(LIST_MIN_PX, rect.width * LIST_MAX_RATIO);
+    const current = parseInt(editor.style.getPropertyValue('--list-w'), 10) || LIST_W_DEFAULT;
+    splitter.setAttribute('aria-valuemin', String(LIST_MIN_PX));
+    splitter.setAttribute('aria-valuemax', String(Math.round(max)));
+    splitter.setAttribute('aria-valuenow', String(Math.round(Math.max(LIST_MIN_PX, Math.min(max, current)))));
+  };
+  const setListWidth = (width: number) => {
+    const rect = editor.getBoundingClientRect();
+    const max = Math.max(LIST_MIN_PX, rect.width * LIST_MAX_RATIO);
+    const clamped = Math.max(LIST_MIN_PX, Math.min(max, width));
+    editor.style.setProperty('--list-w', clamped + 'px');
+    updateSplitterAria();
+    return clamped;
+  };
   const applySavedWidth = () => {
     const saved = vscodeApi.getState() || {};
     // Stacked: drop the override so the single-column grid isn't sized by a stale side-by-side width.
     if (isStacked() || !saved.listW) editor.style.removeProperty('--list-w');
     else editor.style.setProperty('--list-w', saved.listW + 'px');
+    updateSplitterAria();
   };
   // The ResizeObserver below measures the editor element itself and fires on its first observation,
   // so it covers both the initial layout and every later resize — no separate window 'resize'
@@ -109,9 +126,7 @@ function setupSplitter() {
   window.addEventListener('mousemove', e => {
     if (!dragging) return;
     const rect = editor.getBoundingClientRect();
-    const max = Math.max(LIST_MIN_PX, rect.width * LIST_MAX_RATIO);
-    const w = Math.max(LIST_MIN_PX, Math.min(max, e.clientX - rect.left));
-    editor.style.setProperty('--list-w', w + 'px');
+    setListWidth(e.clientX - rect.left);
   });
   window.addEventListener('mouseup', () => {
     if (!dragging) return;
@@ -121,6 +136,22 @@ function setupSplitter() {
     document.body.style.cursor = '';
     const cur = parseInt(editor.style.getPropertyValue('--list-w'), 10) || LIST_W_DEFAULT;
     vscodeApi.setState(Object.assign({}, vscodeApi.getState() || {}, { listW: cur }));
+    updateSplitterAria();
+  });
+  splitter.addEventListener('keydown', e => {
+    if (isStacked()) return;
+    const current = parseInt(editor.style.getPropertyValue('--list-w'), 10) || LIST_W_DEFAULT;
+    const rect = editor.getBoundingClientRect();
+    const max = Math.max(LIST_MIN_PX, rect.width * LIST_MAX_RATIO);
+    let next: number | undefined;
+    if (e.key === 'ArrowLeft') next = current - 16;
+    else if (e.key === 'ArrowRight') next = current + 16;
+    else if (e.key === 'Home') next = LIST_MIN_PX;
+    else if (e.key === 'End') next = max;
+    if (next === undefined) return;
+    e.preventDefault();
+    const width = setListWidth(next);
+    vscodeApi.setState(Object.assign({}, vscodeApi.getState() || {}, { listW: Math.round(width) }));
   });
 }
 setupSplitter();


### PR DESCRIPTION
## What changed

- Add keyboard interaction and focus styling to MPQ archive rows.
- Preserve MPQ folder expansion state when clearing filters.
- Make asset-browser cards and tabs keyboard accessible.
- Add asset-browser dialog semantics, focus trapping, and focus restoration.
- Add keyboard-controlled object-list splitter resizing with ARIA values.
- Improve loading, error, status, and alert semantics across preview surfaces.
- Restore keyboard access to model-preview help.

## Why

This completes the UX/accessibility polish pass for the MPQ viewer, object editor asset browser, model preview, and shared preview states.

## Validation

- `npm test`
- `npx tsc -p . --noEmit`
- `npm run lint` (existing unrelated webpack warning only)
- `npm run compile-web`
- `git diff --check`