### PR TITLE
Polish object editor asset browsing

### DIFF
--- a/scripts/objmod-thumbnail-e2e.js
+++ b/scripts/objmod-thumbnail-e2e.js
@@ -60,8 +60,10 @@ function writeGeneratedObjmodFixture() {
     fs.writeFileSync(path.join(dir, 'wurst.build'), 'projectName = objmod-e2e\n');
     const importedModelsDir = path.join(dir, 'imports', 'units');
     fs.mkdirSync(importedModelsDir, { recursive: true });
+    const validModelFixture = path.join(root, 'wc3data', 'melon.mdx');
+    assert.ok(fs.existsSync(validModelFixture), `Missing valid model fixture: ${validModelFixture}`);
     for (const name of ['Footman.mdx', 'FootmanPortrait.mdx', 'CaptainFootman.mdx', 'confirmation.mdx', 'AltarOfKings.mdx']) {
-        fs.writeFileSync(path.join(importedModelsDir, name), 'objmod search fixture');
+        fs.copyFileSync(validModelFixture, path.join(importedModelsDir, name));
     }
     const localFont = process.env.WURST_OBJMOD_E2E_FONT;
     if (localFont) {
@@ -724,7 +726,7 @@ async function assertObjmodEditorBasics(client, sessionId, contextId) {
         assert.equal(fixtureScore('confirmation.mdx'), undefined, 'scattered letters in confirmation.mdx must not match footman');
         assert.equal(fixtureScore('AltarOfKings.mdx'), undefined, 'unrelated model names must not match footman');
     }
-    log(`footman search returned ${searchResults.length} relevance-sorted results`);
+    log(`footman search returned ${searchResults.length} relevance-sorted results; restoring the unfiltered catalog`);
     await evalInContext(client, sessionId, contextId, 'window.__wurstModelThumbDebug.searchModelAssetBrowser("")');
 }
 

--- a/scripts/objmod-thumbnail-e2e.js
+++ b/scripts/objmod-thumbnail-e2e.js
@@ -16,6 +16,7 @@
  *   WURST_OBJMOD_E2E_MAX_MS     max warm per-thumbnail lifecycle, default 200ms
  *   WURST_OBJMOD_E2E_TIMEOUT_MS total wait timeout, default 90000
  *   WURST_OBJMOD_E2E_FONT_ONLY  stop after verifying a configured tooltip font
+ *   WURST_OBJMOD_E2E_FONT       optional local .ttf copied into the generated fixture and configured
  */
 
 const assert = require('assert');
@@ -57,6 +58,20 @@ function writeGeneratedObjmodFixture() {
     const { serializeObjMod } = require('casc-ts/formats');
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wurst-objmod-fixture-'));
     fs.writeFileSync(path.join(dir, 'wurst.build'), 'projectName = objmod-e2e\n');
+    const importedModelsDir = path.join(dir, 'imports', 'units');
+    fs.mkdirSync(importedModelsDir, { recursive: true });
+    for (const name of ['Footman.mdx', 'FootmanPortrait.mdx', 'CaptainFootman.mdx', 'confirmation.mdx', 'AltarOfKings.mdx']) {
+        fs.writeFileSync(path.join(importedModelsDir, name), 'objmod search fixture');
+    }
+    const localFont = process.env.WURST_OBJMOD_E2E_FONT;
+    if (localFont) {
+        assert.ok(fs.existsSync(localFont), `WURST_OBJMOD_E2E_FONT does not exist: ${localFont}`);
+        const fontName = 'tooltip-e2e.ttf';
+        fs.copyFileSync(localFont, path.join(dir, fontName));
+        const settingsDir = path.join(dir, '.vscode');
+        fs.mkdirSync(settingsDir);
+        fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify({ 'wurst.objModTooltipFont': fontName }));
+    }
     const main = {
         version: 3,
         ext: '.w3a',
@@ -536,24 +551,30 @@ async function assertObjmodEditorBasics(client, sessionId, contextId) {
         btn.click();
         var cozyHeight = row.getBoundingClientRect().height;
         var cozy = document.body.classList.contains('density-cozy');
-        var cozyLabel = btn.textContent;
+        var cozyChecked = btn.getAttribute('aria-checked');
+        var role = btn.getAttribute('role');
+        var label = btn.getAttribute('aria-label');
         btn.click();
         return {
             startedCozy: startedCozy,
             compactHeight: compactHeight,
             cozyHeight: cozyHeight,
             cozy: cozy,
-            cozyLabel: cozyLabel,
+            cozyChecked: cozyChecked,
+            role: role,
+            label: label,
             restored: document.body.classList.contains('density-cozy'),
-            restoredLabel: btn.textContent,
+            restoredChecked: btn.getAttribute('aria-checked'),
         };
     })()`);
     assert.ok(density, 'objmod header should expose a density toggle beside the save badge');
     assert.equal(density.startedCozy, false, 'compact should be the default density');
     assert.equal(density.cozy, true, 'clicking the density toggle should switch to the spacious scale');
-    assert.equal(density.cozyLabel, 'spacious', 'the density toggle should name the mode it is currently in');
+    assert.equal(density.role, 'switch', 'the density control should expose itself as a switch');
+    assert.equal(density.label, 'Spacious density', 'the density switch should have a clear accessible name');
+    assert.equal(density.cozyChecked, 'true', 'the density switch should expose spacious as checked');
     assert.equal(density.restored, false, 'clicking the density toggle again should return to compact');
-    assert.equal(density.restoredLabel, 'compact', 'the density toggle label should follow the mode back');
+    assert.equal(density.restoredChecked, 'false', 'the density switch should expose compact as unchecked');
     assert.ok(
         density.cozyHeight > density.compactHeight,
         `spacious browse rows should be taller than compact ones, got ${density.cozyHeight} vs ${density.compactHeight}`,
@@ -672,6 +693,38 @@ async function assertObjmodEditorBasics(client, sessionId, contextId) {
         15000,
     );
     assert.ok(assetState.visible.some((slot) => /LordaeronTree/i.test(slot.model)), 'LordaeronTree should appear as a model thumbnail slot');
+
+    await evalInContext(client, sessionId, contextId, 'window.__wurstModelThumbDebug.searchModelAssetBrowser("footman")');
+    const searchState = await waitForEval(
+        client,
+        sessionId,
+        contextId,
+        'window.__wurstModelThumbDebug.state()',
+        (value) => value && Array.isArray(value.assetBrowserResults) && value.assetBrowserResults.some((entry) => /footman/i.test(entry.label)),
+        'ranked footman asset search results',
+        15000,
+    );
+    const searchResults = searchState.assetBrowserResults;
+    assert.ok(searchResults.length > 0, 'footman search should return useful model results');
+    assert.ok(
+        searchResults.every((entry) => /footm[ae]n/i.test(`${entry.label} ${entry.value}`)),
+        `footman search should not contain unrelated fuzzy noise: ${JSON.stringify(searchResults)}`,
+    );
+    for (let i = 1; i < searchResults.length; i++) {
+        assert.ok(
+            searchResults[i - 1].score <= searchResults[i].score,
+            `asset search scores should be sorted by relevance: ${JSON.stringify(searchResults)}`,
+        );
+    }
+    if (generatedFixtureDir) {
+        const fixtureScore = (name) => searchResults.find((entry) => entry.label.toLowerCase() === name.toLowerCase())?.score;
+        assert.equal(fixtureScore('Footman.mdx'), 0, 'exact filename search result should rank first');
+        assert.equal(fixtureScore('FootmanPortrait.mdx'), 10, 'filename prefix search result should rank after exact matches');
+        assert.equal(fixtureScore('CaptainFootman.mdx'), 20, 'filename substring search result should rank after prefix matches');
+        assert.equal(fixtureScore('confirmation.mdx'), undefined, 'scattered letters in confirmation.mdx must not match footman');
+        assert.equal(fixtureScore('AltarOfKings.mdx'), undefined, 'unrelated model names must not match footman');
+    }
+    log(`footman search returned ${searchResults.length} relevance-sorted results`);
     await evalInContext(client, sessionId, contextId, 'window.__wurstModelThumbDebug.searchModelAssetBrowser("")');
 }
 

--- a/scripts/test-fuzzy.js
+++ b/scripts/test-fuzzy.js
@@ -16,8 +16,9 @@ const src = fs.readFileSync(srcPath, 'utf8');
 const js = ts.transpileModule(src, { compilerOptions: { module: 'commonjs', target: 'es2020' } }).outputText;
 const mod = { exports: {} };
 new Function('exports', 'module', js)(mod.exports, mod);
-const { fuzzyMatch } = mod.exports;
+const { fuzzyMatch, assetSearchScore } = mod.exports;
 assert.strictEqual(typeof fuzzyMatch, 'function', 'fuzzyMatch should be exported');
+assert.strictEqual(typeof assetSearchScore, 'function', 'assetSearchScore should be exported');
 
 let passed = 0;
 function ok(query, text, expected, msg) {
@@ -56,5 +57,29 @@ ok('xyzqq', 'Graveyard', false);
 
 // threshold stays low — not loose
 ok('catapult', 'Graveyard', false, 'too many edits');
+
+const footmanCandidates = [
+    { label: 'confirmation.mdx', value: 'imports\\other\\ui\\confirmation.mdx' },
+    { label: 'FirePandarenBrewmaster.mdx', value: 'imports\\hero\\FirePandarenBrewmaster.mdx' },
+    { label: 'CaptainFootman.mdx', value: 'imports\\units\\CaptainFootman.mdx' },
+    { label: 'FootmanPortrait.mdx', value: 'imports\\units\\FootmanPortrait.mdx' },
+    { label: 'Footman.mdx', value: 'imports\\units\\Footman.mdx' },
+    { label: 'AltarOfKings - altarofkings', value: 'buildings\\human\\AltarOfKings\\AltarOfKings.mdx' },
+];
+const footmanResults = footmanCandidates
+    .map((item, index) => ({ ...item, index, score: assetSearchScore('footman', item.label, item.value) }))
+    .filter((item) => Number.isFinite(item.score))
+    .sort((a, b) => a.score - b.score || a.index - b.index);
+assert.deepStrictEqual(
+    footmanResults.map((item) => item.label),
+    ['Footman.mdx', 'FootmanPortrait.mdx', 'CaptainFootman.mdx'],
+    'asset search should exclude scattered-letter noise and rank exact, prefix, then substring matches',
+);
+assert.deepStrictEqual(
+    footmanResults.map((item) => item.score),
+    [0, 10, 20],
+    'asset relevance scores should be deterministic',
+);
+passed += 2;
 
 console.log(`fuzzy unit tests passed (${passed} assertions)`);

--- a/scripts/test-webview.js
+++ b/scripts/test-webview.js
@@ -509,6 +509,11 @@ async function testFolderModeMapAssetResolution() {
         roots.some((candidate) => path.resolve(candidate) === path.resolve(imported)),
         'folder-mode map import directory should be a candidate root'
     );
+    const gathered = await mod.gatherImportedAssets(docPath);
+    assert.equal(gathered.icon.length, 1, 'the same imported texture reached through nested candidate roots must appear once');
+    assert.equal(gathered.icon[0].value, 'BrutalLord.blp', 'the most specific asset root should provide the useful WC3-relative path');
+    assert.equal(gathered.model.length, 1, 'the same imported model reached through nested candidate roots must appear once');
+    assert.equal(gathered.model[0].value, 'BrutalLord.mdx');
     const resolved = await mod.resolveAssetPathWithCasc('BrutalLord.blp', roots, 'texture');
     assert.equal(path.resolve(resolved), path.resolve(texturePath));
     const resolvedFromWrongTextureExt = await mod.resolveAssetPathWithCasc('BrutalLord.tif', roots, 'texture');
@@ -717,10 +722,13 @@ function testAssetBrowserForwardsModelTextures() {
     const src = fs.readFileSync(path.join(root, 'src/features/assetLinks.ts'), 'utf8');
     const match = src.match(/<script>\r?\n([\s\S]*?)\r?\n<\/script>`/);
     assert.ok(match, 'asset browser inline script should be present');
-    const script = match[1].replace(
-        'var initial = ${initialJson};',
-        "var initial = { activeTab: 'model', tabs: { icon: [], model: [] }, currentValue: '' };"
-    );
+    const script = match[1]
+        .replace(
+            'var initial = ${initialJson};',
+            "var initial = { activeTab: 'model', tabs: { icon: [], model: [] }, currentValue: '' };"
+        )
+        .replace('${fuzzyMatch.toString()}', 'function fuzzyMatch() { return false; }')
+        .replace('${assetSearchScore.toString()}', 'function assetSearchScore() { return Number.POSITIVE_INFINITY; }');
     // eslint-disable-next-line sonarjs/constructor-for-side-effects -- constructed only to validate the extracted inline script parses (throws SyntaxError otherwise); the instance itself is unused on purpose.
     new vm.Script(script);
     assert.ok(
@@ -742,6 +750,14 @@ function testAssetBrowserForwardsModelTextures() {
     assert.ok(
         !/type === 'requestTextures'\)\s*return/.test(script),
         'asset browser must not silently drop model texture requests'
+    );
+    assert.ok(
+        script.includes('assetSearchScore(query, item.label, item.value, item.detail)'),
+        'code and object-data asset pickers should share the relevance scorer'
+    );
+    assert.ok(
+        !script.includes('text.indexOf(q[i], pos)'),
+        'asset search must not regress to scattered-letter subsequence matching'
     );
 }
 
@@ -778,6 +794,7 @@ function testThumbnailLifecycleGuards() {
     assert.ok(objmod.includes('fetch(initial.thumbnailWorkerUri'), 'the worker bundle must be fetched before creating its Blob URL');
     assert.ok(!objmod.includes('new Worker(initial.thumbnailWorkerUri)'), 'VS Code resource URLs cannot be passed directly to the Worker constructor');
     assert.ok(assetBrowser.includes('modelThumbEnsureInit()'), 'opening or selecting the model asset browser should prewarm the thumbnail worker');
+    assert.ok(assetBrowser.includes("import { assetSearchScore } from '../../features/preview/fuzzy'"), 'objmod asset search should use the shared relevance scorer');
     const ensureInit = /export function modelThumbEnsureInit\(\) \{([\s\S]*?)\n\}/.exec(objmod)?.[1] || '';
     assert.ok(!ensureInit.includes('mpvViewer()'), 'worker startup failure must not fall back to rendering on the objmod UI thread');
     assert.ok(webpack.includes("mdxThumbnailWorker: './src/webview/mdxThumbnailWorker.ts'"), 'the isolated thumbnail worker must be bundled');
@@ -921,6 +938,9 @@ function testObjModTooltipFontWiring() {
     assert.ok(!host.includes("Buffer.from(bytes).toString('base64')"), 'project fonts should not be embedded as large data URLs');
     assert.ok(host.includes(".tt-collapsed-box,\n.tt-preview {"), 'the custom font should be assigned only to tooltip boxes');
     assert.ok(!host.includes('.tt-collapsed-box *'), 'the custom font should not use descendant-wide override selectors');
+    assert.ok(host.includes('td.value { font-family: var(--font); }'), 'ordinary field values should use the VS Code UI font');
+    assert.ok(host.includes('.tt-empty { color: var(--muted); font-style: normal; }'), 'ordinary empty values should not be italicized');
+    assert.ok(host.includes('.tt-collapsed-box .tt-empty,'), 'only framed WC3 text may retain the italic empty placeholder');
     assert.ok(packageJson.includes('wurst.objModTooltipFont'), 'the tooltip font setting should be contributed by the extension');
     assert.equal(packageData.contributes.configuration.properties['wurst.objModTooltipFont'].default, '', 'the tooltip font setting must default to disabled');
 }
@@ -944,8 +964,32 @@ function testObjModTooltipPreviewHeaders() {
     const detailsPanel = fs.readFileSync(path.join(root, 'src/webview/objModEditor/detailsPanel.ts'), 'utf8');
 
     assert.ok(fieldDisplay.includes("replace(/^(?:unit|building)\\s*\\/\\s*/i, '')"), 'unit and building tooltip markers should be hidden in previews');
+    assert.ok(fieldDisplay.includes("label === 'name' || /\\bnames?$/"), 'player-facing name fields should use the framed WC3 text editor');
     assert.ok(detailsPanel.includes('renderWc3Colors(original)'), 'tooltip editing should restore the unmodified raw value');
     assert.ok(detailsPanel.includes('renderWc3Colors(tooltipPreviewText(value, isTooltipTemplateField(mod)))'), 'tooltip collapse should restore the cleaned preview only for tooltip fields');
+}
+
+function testObjModDensityAndTreeStyling() {
+    const host = fs.readFileSync(path.join(root, 'src/features/objModPreview.ts'), 'utf8');
+    const webview = fs.readFileSync(path.join(root, 'src/webview/objModEditorWebview.ts'), 'utf8');
+
+    assert.ok(host.includes('id="density-toggle" class="density-toggle" role="switch"'), 'density must render as an obvious switch control');
+    assert.ok(host.includes('aria-label="Spacious density"'), 'density switch should have an unambiguous accessible name');
+    assert.ok(host.includes('class="density-track"'), 'density switch should expose an animated visual track');
+    assert.ok(host.includes('body.density-cozy .density-thumb { transform: translateX(14px)'), 'density switch thumb should animate between states');
+    assert.ok(host.includes('@media (prefers-reduced-motion: reduce)'), 'density animation should respect reduced-motion preferences');
+    assert.ok(webview.includes("setAttribute('aria-checked', String(cozy))"), 'density switch must expose its current state accessibly');
+    assert.ok(host.includes('font-size: 11px;\n  font-weight: 500;\n  color: var(--muted);'), 'nested tree headings should share one typography baseline');
+    assert.ok(!host.includes('.race-heading {\n  padding: var(--tree-heading-py) var(--ind-group) var(--tree-heading-py) var(--ind-race);\n  color: var(--fg);\n  font-size: 12px;'), 'race headings should not introduce a third font treatment');
+}
+
+function testImportedAssetDedupeSafety() {
+    const host = fs.readFileSync(path.join(root, 'src/features/objModPreview.ts'), 'utf8');
+    const support = fs.readFileSync(path.join(root, 'src/features/imageAssetSupport.ts'), 'utf8');
+
+    assert.ok(!support.includes('hashImportedAsset'), 'asset dedupe must not mistake size+mtime metadata for a content hash');
+    assert.ok(!host.includes('opt.hash'), 'distinct imported files must not collapse through metadata collisions');
+    assert.ok(host.includes("if (opt.source === 'import')"), 'imports in different folders should remain separate after exact-path dedupe');
 }
 
 function testObjModEditorTypeAndRecoveryGuards() {
@@ -993,6 +1037,8 @@ async function main() {
     testObjModTooltipFontWiring();
     testObjModTooltipWidthWiring();
     testObjModTooltipPreviewHeaders();
+    testObjModDensityAndTreeStyling();
+    testImportedAssetDedupeSafety();
     console.log('webview harness tests passed');
 }
 

--- a/scripts/test-webview.js
+++ b/scripts/test-webview.js
@@ -986,10 +986,17 @@ function testObjModDensityAndTreeStyling() {
 function testImportedAssetDedupeSafety() {
     const host = fs.readFileSync(path.join(root, 'src/features/objModPreview.ts'), 'utf8');
     const support = fs.readFileSync(path.join(root, 'src/features/imageAssetSupport.ts'), 'utf8');
+    const e2e = fs.readFileSync(path.join(root, 'scripts/objmod-thumbnail-e2e.js'), 'utf8');
 
     assert.ok(!support.includes('hashImportedAsset'), 'asset dedupe must not mistake size+mtime metadata for a content hash');
     assert.ok(!host.includes('opt.hash'), 'distinct imported files must not collapse through metadata collisions');
     assert.ok(host.includes("if (opt.source === 'import')"), 'imports in different folders should remain separate after exact-path dedupe');
+    assert.ok(
+        support.indexOf('if (seenFile.has(fileKey)) continue;') < support.indexOf('budget--;'),
+        'duplicate physical assets must not consume the imported-asset scan budget',
+    );
+    assert.ok(e2e.includes("path.join(root, 'wc3data', 'melon.mdx')"), 'generated thumbnail search controls should copy a valid model fixture');
+    assert.ok(!e2e.includes("'objmod search fixture'"), 'generated thumbnail fixtures must not contain fake text model bytes');
 }
 
 function testObjModEditorTypeAndRecoveryGuards() {

--- a/src/features/assetLinks.ts
+++ b/src/features/assetLinks.ts
@@ -9,6 +9,7 @@ import { isSoundAssetPath, playSoundInline } from './soundPreview';
 import { buildPage, ICON_INLINE_CSS, PREVIEW_ICON_CSP } from './webviewShared';
 import { escapeHtml } from './webviewUtils';
 import { showWarningWithLogs } from './diagnostics';
+import { assetSearchScore, fuzzyMatch } from './preview/fuzzy';
 
 // Asset file extensions we want to linkify inside string literals
 const ASSET_EXTS = new Set([
@@ -224,7 +225,7 @@ function dedupeAssetOptions(options: readonly ValueOption[]): ValueOption[] {
     const seen = new Set<string>();
     const out: ValueOption[] = [];
     for (const option of options) {
-        const key = option.value.toLowerCase();
+        const key = option.value.replace(/\//g, '\\').toLowerCase();
         if (seen.has(key)) continue;
         seen.add(key);
         out.push(option);
@@ -292,22 +293,20 @@ ${ICON_INLINE_CSS}
   var modelJob = null;
   var modelInited = false;
   function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
-  function fuzzy(q, text) {
-    q = String(q || '').toLowerCase().trim();
-    if (!q) return true;
-    text = String(text || '').toLowerCase();
-    var pos = 0;
-    for (var i = 0; i < q.length; i++) {
-      pos = text.indexOf(q[i], pos);
-      if (pos < 0) return false;
-      pos++;
-    }
-    return true;
-  }
+  var fuzzyMatch = ${fuzzyMatch.toString()};
+  var assetSearchScore = ${assetSearchScore.toString()};
   function list() {
     var items = (initial.tabs[activeTab] || []);
     if (!query) return items.slice(0, 500);
-    return items.filter(function (item) { return fuzzy(query, item.label + ' ' + item.detail + ' ' + item.value); }).slice(0, 500);
+    return items.map(function (item, index) {
+      return { item: item, index: index, score: assetSearchScore(query, item.label, item.value, item.detail) };
+    }).filter(function (entry) {
+      return Number.isFinite(entry.score);
+    }).sort(function (a, b) {
+      return a.score - b.score || a.index - b.index;
+    }).slice(0, 500).map(function (entry) {
+      return entry.item;
+    });
   }
   function render() {
     document.querySelectorAll('.tab').forEach(function (btn) { btn.classList.toggle('active', btn.getAttribute('data-tab') === activeTab); });

--- a/src/features/imageAssetSupport.ts
+++ b/src/features/imageAssetSupport.ts
@@ -227,19 +227,9 @@ async function getCandidateRootsUncached(documentFsPath: string): Promise<string
     return roots;
 }
 
-export interface ImportedAsset { value: string; label: string; iconPath?: string; source: 'import'; hash?: string; }
+export interface ImportedAsset { value: string; label: string; iconPath?: string; source: 'import'; }
 
 const IMPORT_SKIP_DIRS = new Set(['node_modules', '.git', '.svn', 'dist', 'out', 'build', '_build', 'target', '.wurst', 'wurst', '.idea', '.vscode']);
-
-async function hashImportedAsset(fullPath: string): Promise<string | undefined> {
-    try {
-        const stat = await fs.promises.stat(fullPath);
-        if (!stat.isFile()) return undefined;
-        return `${stat.size}:${Math.floor(stat.mtimeMs)}`;
-    } catch {
-        return undefined;
-    }
-}
 
 /**
  * Enumerate user-imported asset files (models + textures + sounds) under the project's local roots, so the
@@ -248,11 +238,16 @@ async function hashImportedAsset(fullPath: string): Promise<string | undefined> 
  */
 export async function gatherImportedAssets(documentFsPath: string): Promise<{ model: ImportedAsset[]; icon: ImportedAsset[]; sound: ImportedAsset[] }> {
     const cacheDir = getGameAssetCacheDir();
-    const roots = (await getCandidateRoots(documentFsPath)).filter((r) => r !== cacheDir);
+    // Prefer the most specific root. A file under `imports\btn` is reachable both from the workspace
+    // root (`imports\btn\x.blp`) and the dedicated imports root (`btn\x.blp`); the latter is the useful
+    // WC3 asset path. Walking child roots first also lets the physical-path guard below keep that form.
+    const roots = (await getCandidateRoots(documentFsPath))
+        .filter((r) => r !== cacheDir)
+        .sort((a, b) => path.resolve(b).split(path.sep).length - path.resolve(a).split(path.sep).length);
     const model: ImportedAsset[] = [];
     const icon: ImportedAsset[] = [];
     const sound: ImportedAsset[] = [];
-    const seenValue = new Set<string>();
+    const seenFile = new Set<string>();
     let budget = 4000;
 
     // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO(lint-cleanup): pre-existing, tracked for a dedicated decomposition pass rather than a rushed refactor here.
@@ -274,12 +269,12 @@ export async function gatherImportedAssets(documentFsPath: string): Promise<{ mo
             const isTex = ext === 'blp' || ext === 'dds' || ext === 'tga';
             const isSound = SOUND_EXTS.has(ext);
             if (!isModel && !isTex && !isSound) continue;
+            const resolved = path.resolve(full);
+            const fileKey = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+            if (seenFile.has(fileKey)) continue;
+            seenFile.add(fileKey);
             const rel = path.relative(root, full).replace(/\//g, '\\');
-            const key = rel.toLowerCase();
-            if (seenValue.has(key)) continue;
-            seenValue.add(key);
-            const hash = await hashImportedAsset(full);
-            const opt: ImportedAsset = { value: rel, label: entry.name, source: 'import', hash };
+            const opt: ImportedAsset = { value: rel, label: entry.name, source: 'import' };
             if (isTex) { opt.iconPath = rel; icon.push(opt); }
             else if (isSound) { sound.push(opt); }
             else { model.push(opt); }

--- a/src/features/imageAssetSupport.ts
+++ b/src/features/imageAssetSupport.ts
@@ -263,15 +263,17 @@ export async function gatherImportedAssets(documentFsPath: string): Promise<{ mo
                 await walk(root, full, depth + 1);
                 continue;
             }
+            const resolved = path.resolve(full);
+            const fileKey = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+            // Overlapping candidate roots can reach the same asset more than once. Do not let those
+            // duplicate visits consume the bounded scan budget and hide later unique assets.
+            if (seenFile.has(fileKey)) continue;
             budget--;
             const ext = path.extname(entry.name).slice(1).toLowerCase();
             const isModel = ext === 'mdx' || ext === 'mdl';
             const isTex = ext === 'blp' || ext === 'dds' || ext === 'tga';
             const isSound = SOUND_EXTS.has(ext);
             if (!isModel && !isTex && !isSound) continue;
-            const resolved = path.resolve(full);
-            const fileKey = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-            if (seenFile.has(fileKey)) continue;
             seenFile.add(fileKey);
             const rel = path.relative(root, full).replace(/\//g, '\\');
             const opt: ImportedAsset = { value: rel, label: entry.name, source: 'import' };

--- a/src/features/objModPreview.ts
+++ b/src/features/objModPreview.ts
@@ -197,7 +197,6 @@ export interface ValueOption {
     iconPath?: string;
     objectKey?: string;
     source?: 'import';
-    hash?: string;
 }
 
 interface ObjEditorData {
@@ -1458,15 +1457,22 @@ function resolveProfileDisplayName(row: Record<string, string>, worldStrings: Ma
     return value ? resolveWorldEditString(value, worldStrings) : undefined;
 }
 
-/** Collapse options whose file basename (sans extension/folder) is identical — e.g. SD/HD/.blp/.dds
- *  variants of the same icon. Keeps the first occurrence (imports are prepended, so they win). */
-function dedupeByHashOrBasename(options: ValueOption[]): ValueOption[] {
+/** Collapse exact path duplicates, plus WC3 catalog entries whose basename (sans extension/folder)
+ *  is identical (for example SD/HD/.blp/.dds variants). Imported files in separate folders stay. */
+function dedupeByPathOrCatalogBasename(options: ValueOption[]): ValueOption[] {
     const seen = new Set<string>();
+    const seenValues = new Set<string>();
     const out: ValueOption[] = [];
     for (const opt of options) {
+        const value = opt.value.replace(/\//g, '\\').toLowerCase();
+        if (seenValues.has(value)) continue;
+        seenValues.add(value);
+        if (opt.source === 'import') {
+            out.push(opt);
+            continue;
+        }
         const base = (opt.value.split(/[\\/]/).pop() ?? opt.value).replace(/\.[^.]+$/, '').toLowerCase();
-        const source = opt.source === 'import' ? 'import' : 'wc3';
-        const key = opt.hash ? `${source}:hash:${opt.hash}` : `${source}:base:${base}`;
+        const key = `wc3:base:${base}`;
         if (seen.has(key)) continue;
         seen.add(key);
         out.push(opt);
@@ -1884,10 +1890,56 @@ body.density-cozy #density-toggle { margin-left: auto; }
 /* Same pill shape as the save badge, but a neutral (non-accent) affordance — it's a view preference,
    not document state. */
 .density-toggle {
-  border-color: var(--border);
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--input-bg);
   color: var(--muted);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+  transition: color .16s, border-color .16s, background-color .16s;
 }
-.density-toggle:hover { background: var(--hover); color: var(--fg); }
+.density-toggle:hover { background: var(--hover); color: var(--fg); border-color: var(--vscode-focusBorder, var(--border)); }
+.density-toggle:focus-visible { outline: 2px solid var(--vscode-focusBorder, #007fd4); outline-offset: 1px; }
+.density-option { transition: color .16s, opacity .16s; }
+.density-option-compact { color: var(--fg); font-weight: 600; }
+.density-track {
+  position: relative;
+  width: 28px;
+  height: 14px;
+  box-sizing: border-box;
+  border: 1px solid color-mix(in srgb, var(--muted) 65%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 18%, transparent);
+  transition: background-color .2s, border-color .2s;
+}
+.density-thumb {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--fg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .35);
+  transform: translateX(0);
+  transition: transform .22s cubic-bezier(.2, .8, .2, 1), background-color .2s;
+}
+body.density-cozy .density-option-compact { color: var(--muted); font-weight: 400; }
+body.density-cozy .density-option-cozy { color: var(--fg); font-weight: 600; }
+body.density-cozy .density-track { background: color-mix(in srgb, var(--accent) 42%, transparent); border-color: var(--accent); }
+body.density-cozy .density-thumb { transform: translateX(14px); background: var(--accent); }
+@media (prefers-reduced-motion: reduce) {
+  .density-toggle,
+  .density-option,
+  .density-track,
+  .density-thumb { transition: none; }
+}
 .error,
 .warning {
   padding: calc(var(--head-py) + 1px) var(--pad-x);
@@ -1907,7 +1959,7 @@ body.density-cozy #density-toggle { margin-left: auto; }
   border-radius: 2px;
   padding: 2px 6px;
   font: inherit;
-  font-family: var(--mono);
+  font-family: var(--font);
 }
 /* Single-line inputs match the collapsed cell height exactly, so toggling edit never resizes the row. */
 input.edit-raw { height: var(--cell-h); }
@@ -2055,7 +2107,9 @@ textarea.edit-raw { min-height: 48px; line-height: 1.4; padding: 4px 6px; resize
 .tt-collapsed:focus-visible { outline: none; }
 .tt-collapsed-body { min-width: 0; }
 .tt-collapsed-body[contenteditable="true"] { outline: none; cursor: text; }
-.tt-empty { color: var(--muted); font-style: italic; }
+.tt-empty { color: var(--muted); font-style: normal; }
+.tt-collapsed-box .tt-empty,
+.tt-preview .tt-empty { font-style: italic; }
 .tt-edit-hint {
   flex-shrink: 0;
   color: var(--muted);
@@ -2119,7 +2173,7 @@ textarea.edit-raw { min-height: 48px; line-height: 1.4; padding: 4px 6px; resize
 /* Shrink-to-fit, not flex:1 — the "modified" badge, source pill and ✎ hint cluster right after the
    value instead of being flung to the far edge of a wide value column. The click target is still the
    full cell (.cell-edit stays width:100%). */
-.cell-edit-val { flex: 0 1 auto; min-width: 0; font-family: var(--mono); word-break: break-word; white-space: pre-wrap; }
+.cell-edit-val { flex: 0 1 auto; min-width: 0; font-family: var(--font); word-break: break-word; white-space: pre-wrap; }
 .value-display {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
@@ -2140,7 +2194,7 @@ textarea.edit-raw { min-height: 48px; line-height: 1.4; padding: 4px 6px; resize
   grid-column: 2;
   min-width: 0;
   color: var(--muted);
-  font-family: var(--mono);
+  font-family: var(--font);
   font-size: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2693,7 +2747,8 @@ tr.hidden { display: none; }
   background: transparent;
   border: 0;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
+  color: var(--muted);
   text-align: left;
   cursor: pointer;
 }
@@ -2702,16 +2757,15 @@ tr.hidden { display: none; }
   top: 0;
   z-index: 1;
   padding: var(--tree-heading-py) var(--ind-group);
-  color: var(--muted);
+  color: var(--fg);
+  font-weight: 600;
   background: var(--sidebar);
 }
 .race-heading {
   padding: var(--tree-heading-py) var(--ind-group) var(--tree-heading-py) var(--ind-race);
-  color: var(--fg);
-  font-size: 12px;
 }
-.camp-heading { padding: var(--tree-row-py) var(--ind-group) var(--tree-row-py) var(--ind-camp); color: var(--muted); }
-.kind-heading { padding: var(--tree-row-py) var(--ind-group) var(--tree-row-py) var(--ind-kind); color: var(--muted); font-weight: 500; }
+.camp-heading { padding: var(--tree-row-py) var(--ind-group) var(--tree-row-py) var(--ind-camp); }
+.kind-heading { padding: var(--tree-row-py) var(--ind-group) var(--tree-row-py) var(--ind-kind); }
 .group-heading:hover,
 .race-heading:hover,
 .camp-heading:hover,
@@ -2930,10 +2984,10 @@ td {
 }
 tbody tr:hover td { background: color-mix(in srgb, var(--hover) 55%, transparent); }
 td.id,
-td.num,
-td.value {
+td.num {
   font-family: var(--mono);
 }
+td.value { font-family: var(--font); }
 td.label { color: var(--fg); }
 td.type { color: var(--muted); font-size: 11px; }
 td.num { text-align: right; color: var(--muted); }
@@ -3025,7 +3079,11 @@ ${tooltipFontCss}
 <div class="md-header">
   <span class="md-title" title="${escapeHtml(fileName)}">${escapeHtml(fileName)}</span>
   <span class="md-meta" title="${escapeHtml(metaLine)}">${escapeHtml(metaLine)}</span>
-  <button type="button" id="density-toggle" class="editable-badge density-toggle" aria-pressed="false" title="Switch between compact and spacious spacing">compact</button>
+  <button type="button" id="density-toggle" class="density-toggle" role="switch" aria-checked="false" aria-label="Spacious density" title="Use spacious density">
+    <span class="density-option density-option-compact">Compact</span>
+    <span class="density-track" aria-hidden="true"><span class="density-thumb"></span></span>
+    <span class="density-option density-option-cozy">Spacious</span>
+  </button>
   <button type="button" id="editable-badge" class="editable-badge" title="Existing overrides can be edited. Click or Ctrl+S to save.">editable</button>
 </div>
 ${errorBanner}
@@ -3676,10 +3734,10 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
                 ]);
                 void webview.postMessage({
                     type: 'assetCatalog',
-                    models: dedupeByHashOrBasename([...cat.models, ...imp.model]),
+                    models: dedupeByPathOrCatalogBasename([...imp.model, ...cat.models]),
                     // Icons repeat across SD/HD and .blp/.dds/.tga variants — collapse same-named ones.
-                    icons: dedupeByHashOrBasename([...cat.icons, ...imp.icon]),
-                    sounds: dedupeByHashOrBasename([...cat.sounds, ...imp.sound]),
+                    icons: dedupeByPathOrCatalogBasename([...imp.icon, ...cat.icons]),
+                    sounds: dedupeByPathOrCatalogBasename([...imp.sound, ...cat.sounds]),
                     pathing: cat.pathing,
                 });
             } catch (err) {

--- a/src/features/preview/fuzzy.ts
+++ b/src/features/preview/fuzzy.ts
@@ -44,3 +44,33 @@ export function fuzzyMatch(query: string, text: string): boolean {
     for (let j = 0; j <= m; j++) if (prev[j] < min) min = prev[j];
     return min <= max;
 }
+
+/**
+ * Relevance score for asset-picker entries. Lower is better; Infinity means no match.
+ *
+ * Keep this dependency-free and reference only `fuzzyMatch`: the code-asset picker ships both
+ * functions into its webview with `.toString()`. Search individual fields instead of one joined
+ * haystack so a query cannot be assembled from unrelated letters across a label, path, and detail.
+ */
+export function assetSearchScore(query: string, label: string, value: string, detail = ''): number {
+    const q = String(query === null || query === undefined ? '' : query).toLowerCase().trim();
+    if (!q) return 0;
+
+    const rawLabel = String(label === null || label === undefined ? '' : label);
+    const normalizedValue = String(value === null || value === undefined ? '' : value).replace(/\\/g, '/');
+    const basename = normalizedValue.slice(normalizedValue.lastIndexOf('/') + 1).toLowerCase();
+    const stem = basename.replace(/\.[^.]+$/, '');
+    const normalizedLabel = rawLabel.toLowerCase().trim();
+    const labelStem = normalizedLabel.replace(/\.[^.]+$/, '');
+    const labelWords = rawLabel.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+    const valueWords = normalizedValue.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+
+    if (labelStem === q || stem === q) return 0;
+    if (labelStem.startsWith(q) || stem.startsWith(q)) return 10;
+    if (normalizedLabel.includes(q) || basename.includes(q)) return 20;
+    if (labelWords.includes(q)) return 30;
+    if (valueWords.includes(q)) return 40;
+    if (String(detail === null || detail === undefined ? '' : detail).toLowerCase().includes(q)) return 50;
+    if (fuzzyMatch(q, labelStem) || fuzzyMatch(q, stem)) return 80;
+    return Number.POSITIVE_INFINITY;
+}

--- a/src/webview/objModEditor/assetBrowser.ts
+++ b/src/webview/objModEditor/assetBrowser.ts
@@ -1,4 +1,4 @@
-import { fuzzyMatch } from '../../features/preview/fuzzy';
+import { assetSearchScore } from '../../features/preview/fuzzy';
 import { esc } from '../objModWebviewUtils';
 import { effect, signal } from '../signals';
 import { detailCache, details, ui, vscodeApi, iconLoader, assetBrowserUi } from './state';
@@ -118,19 +118,21 @@ export function renderAssetGrid() {
   const opts = (catalog && catalog[activeTab]) || [];
   const sourceFilter = assetBrowserUi.sourceFilter;
   const query = assetBrowserUi.searchQuery.trim();
-  const matches: AssetOption[] = [];
-  let matchedCount = 0;
-  for (const o of opts) {
+  const ranked: Array<{ option: AssetOption; score: number; index: number }> = [];
+  for (let index = 0; index < opts.length; index++) {
+    const o = opts[index];
     if (sourceFilter === 'import' && o.source !== 'import') continue;
     if (sourceFilter === 'wc3' && o.source === 'import') continue;
-    if (query && !fuzzyMatch(query, o.label + ' ' + o.value + ' ' + (o.detail || ''))) continue;
-    matchedCount++;
-    if (matches.length < 600) matches.push(o);
+    const score = assetSearchScore(query, o.label, o.value, o.detail || '');
+    if (!Number.isFinite(score)) continue;
+    ranked.push({ option: o, score, index });
   }
+  if (query) ranked.sort((a, b) => a.score - b.score || a.index - b.index);
+  const matches = ranked.slice(0, 600);
   const count = document.getElementById('ab-count');
-  if (count) count.textContent = matches.length + (matchedCount > 600 ? '+' : '') + ' / ' + opts.length;
+  if (count) count.textContent = matches.length + (ranked.length > 600 ? '+' : '') + ' / ' + opts.length;
   if (!matches.length) { grid.innerHTML = '<div class="ab-empty">No matching assets</div>'; return; }
-  grid.innerHTML = matches.map(o => {
+  grid.innerHTML = matches.map(({ option: o, score }) => {
     const icon = activeTab === 'model'
       ? '<span class="object-icon model-thumb" data-key="ab-model:' + esc(o.value) + '" data-model="' + esc(o.value) + '"></span>'
       : activeTab === 'sound'
@@ -139,7 +141,7 @@ export function renderAssetGrid() {
         ? '<span class="object-icon" data-key="ab:' + esc(o.value) + '" data-icon="' + esc(o.iconPath) + '"></span>'
         : '<span class="object-icon missing"></span>');
     const previewHint = activeTab === 'model' ? ' — Ctrl+click to open full preview' : '';
-    return '<button type="button" class="ab-card" data-value="' + esc(o.value) + '" aria-label="' + esc(o.label + ' — ' + o.value) + '" title="' + esc(o.label + ' — ' + o.value + previewHint) + '">' +
+    return '<button type="button" class="ab-card" data-value="' + esc(o.value) + '" data-search-score="' + score + '" aria-label="' + esc(o.label + ' — ' + o.value) + '" title="' + esc(o.label + ' — ' + o.value + previewHint) + '">' +
       icon + '<span class="ab-card-label">' + esc(o.label) + '</span></button>';
   }).join('');
   iconLoader.observe(grid);

--- a/src/webview/objModEditor/debugApi.ts
+++ b/src/webview/objModEditor/debugApi.ts
@@ -164,12 +164,21 @@ export function installDebugApi() {
           visible: isModelThumbActuallyVisible(el),
         };
       });
+      const assetBrowserResults = Array.prototype.slice.call(document.querySelectorAll('#ab-grid .ab-card')).map(function (el, index) {
+        return {
+          index: index,
+          label: el.querySelector('.ab-card-label')?.textContent || '',
+          value: el.getAttribute('data-value') || '',
+          score: Number(el.getAttribute('data-search-score')),
+        };
+      });
       return {
         fileInfo: initial.fileInfo || null,
         selectedKey: ui.selectedKey,
         selectedObject: objects.find(function (candidate) { return candidate.key === ui.selectedKey; }) || null,
         assetBrowserOpen: isAssetBrowserOpen(),
         assetBrowserCount: document.querySelectorAll('#ab-grid .ab-card').length,
+        assetBrowserResults: assetBrowserResults,
         assetCatalogLoaded: !!getAssetCatalog(),
         assetCatalogCounts: getAssetCatalog() ? {
           models: (getAssetCatalog().model || []).length,

--- a/src/webview/objModEditor/fieldDisplay.ts
+++ b/src/webview/objModEditor/fieldDisplay.ts
@@ -26,15 +26,16 @@ export function tooltipPreviewText(v, stripTemplatePrefix = true) {
   return stripTemplatePrefix ? text.replace(/^(?:unit|building)\s*\/\s*/i, '') : text;
 }
 
-// Only genuine display-text fields get the color tools: tooltips/descriptions/tips, or any value
-// that already uses WC3 color codes / newlines. Short codes (hotkeys), names, comma rawcode lists
-// etc. get a plain input — no color bloat.
+// Only genuine player-facing display-text fields get the framed editor: tooltips, descriptions, tips,
+// names, or any value that already uses WC3 color codes/newlines. Technical name variants such as the
+// World Editor suffix, short codes (hotkeys), and comma rawcode lists stay plain.
 export function needsColorEditor(mod) {
   if (!mod.editable || mod.varType !== 'string') return false;
   const v = mod.editValue == null ? '' : String(mod.editValue);
   if (hasColorMarkup(v)) return true;
   const label = String(mod.label || '').toLowerCase();
-  return label.indexOf('tooltip') !== -1 || label.indexOf('description') !== -1 || label.indexOf('tip') !== -1;
+  const isName = !label.includes('editor suffix') && (label === 'name' || /\bnames?$/.test(label));
+  return isName || label.indexOf('tooltip') !== -1 || label.indexOf('description') !== -1 || label.indexOf('tip') !== -1;
 }
 
 // WC3 palette (RRGGBB) for the quick swatches inside the color popup.

--- a/src/webview/objModEditorWebview.ts
+++ b/src/webview/objModEditorWebview.ts
@@ -210,8 +210,8 @@ effect(() => {
   const cozy = ui.density === 'cozy';
   document.body.classList.toggle('density-cozy', cozy);
   if (densityToggle) {
-    densityToggle.textContent = cozy ? 'spacious' : 'compact';
-    densityToggle.setAttribute('aria-pressed', String(cozy));
+    densityToggle.setAttribute('aria-checked', String(cozy));
+    densityToggle.setAttribute('title', cozy ? 'Use compact density' : 'Use spacious density');
   }
 }, 'objModEditor.density');
 if (densityToggle) {


### PR DESCRIPTION
## Summary

- deduplicate imported and Warcraft III catalog assets without collapsing distinct imports
- scope the project tooltip font to framed player-facing text and simplify empty/tree typography
- replace the ambiguous density badge with an accessible animated compact/spacious switch
- give both asset-picker contexts one shared relevance-ranked search implementation
- extend unit, webview, and local VS Code e2e coverage for deduplication, typography, density, and search ordering

## Root cause

The two asset-picker hosts had drifted: the source-code picker still used a scattered-letter subsequence matcher, while the object-data picker used a boolean fuzzy matcher over a concatenated label/path/detail string. Neither produced relevance scores, so accepted entries stayed in catalog order. Imported assets were also reachable through overlapping candidate roots, producing duplicate paths.

## Impact

Searches such as `footman` now return exact filename, prefix, substring, and bounded typo matches in relevance order, without unrelated entries such as `confirmation.mdx`. Imported files appear once, ordinary fields retain the normal VS Code font, and density is visibly interactive while compact remains the default.

## Validation

- `npx tsc -p . --noEmit`
- `npm run lint` (0 errors; one pre-existing `CopyFilePlugin` warning)
- `npm test`
- `npm run vscode:prepublish`
- local VS Code objmod e2e with a deterministic `footman` query, relevance-order assertions, negative controls, and tooltip-font scoping