### PR TITLE
Release v0.12.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wurst",
-    "version": "0.12.14",
+    "version": "0.12.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wurst",
-            "version": "0.12.14",
+            "version": "0.12.15",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "casc-ts": "file:../casc-ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "type": "git",
         "url": "https://github.com/wurstscript/wurst4vscode.git"
     },
-    "version": "0.12.14",
+    "version": "0.12.15",
     "publisher": "peterzeller",
     "engines": {
         "vscode": "^1.109.0"
@@ -491,7 +491,7 @@
             },
             {
                 "viewType": "wurst.wpmPreview",
-                "displayName": "WC3 Pathing Map",
+                "displayName": "WC3 Pathing Map (editable)",
                 "selector": [
                     {
                         "filenamePattern": "*.wpm"
@@ -891,6 +891,7 @@
         "test:webview": "node ./scripts/test-webview.js",
         "test:e2e:models:local": "node ./scripts/model-thumbnail-e2e.js",
         "test:e2e:objmod-thumbs:local": "node ./scripts/objmod-thumbnail-e2e.js",
+        "test:e2e:asset-browser-code:local": "node ./scripts/objmod-thumbnail-e2e.js --code-only",
         "test:e2e:objmod-clipboard:local": "node ./scripts/objmod-clipboard-e2e.js",
         "test:wc3-previews": "node ./scripts/wc3-preview-smoke.js",
         "test:fuzzy": "node ./scripts/test-fuzzy.js",

--- a/scripts/objmod-thumbnail-e2e.js
+++ b/scripts/objmod-thumbnail-e2e.js
@@ -1,15 +1,17 @@
 'use strict';
 
 /**
- * Local-only VS Code extension e2e for objmod asset-browser thumbnails.
+ * Local-only VS Code extension e2e for objmod thumbnails and both asset-browser variants.
  *
  * Enable explicitly, never in CI:
  *   $env:WURST_OBJMOD_E2E='1'
  *   npm run test:e2e:objmod-thumbs:local
+ *   npm run test:e2e:asset-browser-code:local
  *
  * Optional knobs:
  *   WURST_OBJMOD_E2E_PROJECT    defaults to ./e2e
  *   WURST_OBJMOD_E2E_FILE       defaults to ./e2e/war3map.w3u
+ *   WURST_OBJMOD_E2E_CODE_FILE  optional .wurst file used for the code-launched asset-browser check
  *   WURST_OBJMOD_E2E_CODE       Code.exe path, if it cannot be found
  *   WURST_OBJMOD_E2E_COUNT      max visible thumbnails to assert, default all visible
  *   WURST_OBJMOD_E2E_SEARCH     optional model-catalog search query
@@ -29,6 +31,7 @@ const path = require('path');
 
 const root = path.resolve(__dirname, '..');
 const enabled = process.env.WURST_OBJMOD_E2E === '1' || process.env.WURST_LOCAL_E2E === '1';
+const codeOnly = process.argv.includes('--code-only');
 
 if (!enabled) {
     console.log('local objmod thumbnail e2e skipped (set WURST_OBJMOD_E2E=1 to enable)');
@@ -43,6 +46,7 @@ const defaultProjectPath = path.join(root, 'e2e');
 const defaultObjmodFile = path.join(defaultProjectPath, 'war3map.w3u');
 let projectPath = process.env.WURST_OBJMOD_E2E_PROJECT || defaultProjectPath;
 let objmodFile = process.env.WURST_OBJMOD_E2E_FILE || defaultObjmodFile;
+let codeAssetFile = process.env.WURST_OBJMOD_E2E_CODE_FILE || '';
 const sampleCountRaw = process.env.WURST_OBJMOD_E2E_COUNT;
 const sampleCount = sampleCountRaw ? Number(sampleCountRaw) : 0;
 const sampleLimit = Number.isFinite(sampleCount) && sampleCount > 0 ? sampleCount : Number.POSITIVE_INFINITY;
@@ -108,7 +112,9 @@ function writeGeneratedObjmodFixture() {
     };
     fs.writeFileSync(path.join(dir, 'war3map.w3a'), serializeObjMod(main));
     fs.writeFileSync(path.join(dir, 'war3mapSkin.w3a'), serializeObjMod(skin));
-    return { dir, file: path.join(dir, 'war3map.w3a') };
+    const codeFile = path.join(dir, 'AssetBrowserE2e.wurst');
+    fs.writeFileSync(codeFile, 'package AssetBrowserE2e\n\nconstant TEST_MODEL = "imports\\\\units\\\\Footman.mdx"\n');
+    return { dir, file: path.join(dir, 'war3map.w3a'), codeFile };
 }
 
 let generatedFixtureDir = '';
@@ -117,10 +123,13 @@ if (!process.env.WURST_OBJMOD_E2E_PROJECT && !process.env.WURST_OBJMOD_E2E_FILE)
     generatedFixtureDir = generated.dir;
     projectPath = generated.dir;
     objmodFile = generated.file;
+    codeAssetFile = generated.codeFile;
 }
 
 assert.ok(projectPath && fs.existsSync(projectPath), 'Set WURST_OBJMOD_E2E_PROJECT to a real Wurst project folder, or keep ./e2e present.');
 assert.ok(objmodFile && fs.existsSync(objmodFile), 'Set WURST_OBJMOD_E2E_FILE to a real .w3u/.w3a/... file, or keep ./e2e/war3map.w3u present.');
+if (codeAssetFile) assert.ok(fs.existsSync(codeAssetFile), `WURST_OBJMOD_E2E_CODE_FILE does not exist: ${codeAssetFile}`);
+if (codeOnly) assert.ok(codeAssetFile, 'The code-only e2e needs the generated fixture or WURST_OBJMOD_E2E_CODE_FILE.');
 
 function log(message) {
     console.log(`[objmod-thumb-e2e] ${message}`);
@@ -188,6 +197,19 @@ function waitForExit(child, timeoutMs = 5000) {
             resolve();
         });
     });
+}
+
+function bringVsCodeWindowToForeground(userDataDir) {
+    if (process.platform !== 'win32') return;
+    const result = childProcess.spawnSync('powershell.exe', [
+        '-NoProfile',
+        '-File', path.join(__dirname, 'bring-to-foreground.ps1'),
+        '-Needle', userDataDir,
+    ], { encoding: 'utf8', windowsHide: true, timeout: 10000 });
+    if (process.env.WURST_E2E_VERBOSE === '1') {
+        const stderrSuffix = result.stderr ? ' stderr=' + result.stderr.trim() : '';
+        console.log(`[verbose] bringVsCodeWindowToForeground: ${(result.stdout || '').trim() || '(no matching window)'}${stderrSuffix}`);
+    }
 }
 
 function windowsCodePidsForUserDataDir(userDataDir) {
@@ -379,9 +401,11 @@ class CdpClient {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO(lint-cleanup): pre-existing, tracked for a dedicated decomposition pass rather than a rushed refactor here.
-async function waitForWebviewContext(client) {
+async function waitForWebviewContext(client, requireObjmod = true) {
     const contexts = new Map();
     const attachedTargets = new Set();
+    const sessionByTargetId = new Map();
+    let pageSessionId = '';
     client.on('Runtime.executionContextCreated', ({ context }, sessionId) => {
         if (context && context.id && sessionId) contexts.set(`${sessionId}:${context.id}`, { sessionId, context });
     });
@@ -395,6 +419,7 @@ async function waitForWebviewContext(client) {
                 const attached = await client.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
                 if (attached?.sessionId) {
                     attachedTargets.add(target.targetId);
+                    sessionByTargetId.set(target.targetId, attached.sessionId);
                     await client.send('Runtime.enable', {}, attached.sessionId);
                     await client.send('Log.enable', {}, attached.sessionId).catch(() => undefined);
                 }
@@ -402,19 +427,30 @@ async function waitForWebviewContext(client) {
                 attachedTargets.add(target.targetId);
             }
         }
+        for (const target of targets?.targetInfos || []) {
+            if (target.type === 'page' && sessionByTargetId.has(target.targetId)) {
+                pageSessionId = sessionByTargetId.get(target.targetId);
+            }
+        }
+        if (!requireObjmod && pageSessionId) {
+            return { pageSessionId, contexts, attachedTargets, sessionByTargetId };
+        }
         for (const { sessionId, context } of contexts.values()) {
             const result = await client.send('Runtime.evaluate', {
                 contextId: context.id,
                 expression: '!!window.__wurstModelThumbDebug',
                 returnByValue: true,
             }, sessionId).catch(() => undefined);
-            if (result?.result?.value) return { sessionId, contextId: context.id };
+            if (result?.result?.value) {
+                return { sessionId, contextId: context.id, pageSessionId, contexts, attachedTargets, sessionByTargetId };
+            }
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
     }
     const targets = await client.send('Target.getTargets').catch(() => undefined);
     const summary = (targets?.targetInfos || []).map((target) => `${target.type}:${target.title || target.url || target.targetId}`).join(' | ');
-    throw new Error(`Timed out waiting for objmod webview debug hook. Targets: ${summary}`);
+    const wanted = requireObjmod ? 'objmod webview debug hook' : 'extension-host workbench';
+    throw new Error(`Timed out waiting for ${wanted}. Targets: ${summary}`);
 }
 
 async function evalInContext(client, sessionId, contextId, expression) {
@@ -439,6 +475,156 @@ async function waitForEval(client, sessionId, contextId, expression, predicate, 
         await new Promise((resolve) => setTimeout(resolve, 100));
     }
     throw new Error(`Timed out waiting for ${label}. Last value: ${JSON.stringify(last)}`);
+}
+
+async function pressKeyCombo(client, sessionId, keys) {
+    for (const key of keys) {
+        await client.send('Input.dispatchKeyEvent', {
+            type: 'rawKeyDown',
+            modifiers: key.modifiers || 0,
+            key: key.key,
+            code: key.code,
+            windowsVirtualKeyCode: key.vk,
+            nativeVirtualKeyCode: key.vk,
+        }, sessionId);
+    }
+    for (const key of [...keys].reverse()) {
+        await client.send('Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            modifiers: 0,
+            key: key.key,
+            code: key.code,
+            windowsVirtualKeyCode: key.vk,
+            nativeVirtualKeyCode: key.vk,
+        }, sessionId);
+    }
+}
+
+async function typeText(client, sessionId, value) {
+    for (const ch of value) {
+        await client.send('Input.dispatchKeyEvent', { type: 'char', text: ch, key: ch, unmodifiedText: ch }, sessionId);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+    }
+}
+
+async function pressEnter(client, sessionId) {
+    await client.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 }, sessionId);
+    await client.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 }, sessionId);
+}
+
+async function evalInSession(client, sessionId, expression) {
+    const result = await client.send('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true }, sessionId);
+    if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || 'workbench evaluation failed');
+    return result.result.value;
+}
+
+async function waitForSessionEval(client, sessionId, expression, predicate, label, waitMs = timeoutMs) {
+    const deadline = Date.now() + waitMs;
+    let last;
+    while (Date.now() < deadline) {
+        last = await evalInSession(client, sessionId, expression);
+        if (predicate(last)) return last;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`Timed out waiting for ${label}. Last value: ${JSON.stringify(last)}`);
+}
+
+async function attachUntrackedTargets(client, tracking) {
+    const targets = await client.send('Target.getTargets').catch(() => undefined);
+    for (const target of targets?.targetInfos || []) {
+        if (!target.targetId || tracking.attachedTargets.has(target.targetId)) continue;
+        if (!['page', 'iframe', 'webview'].includes(target.type)) continue;
+        try {
+            const attached = await client.send('Target.attachToTarget', { targetId: target.targetId, flatten: true });
+            if (!attached?.sessionId) continue;
+            tracking.attachedTargets.add(target.targetId);
+            tracking.sessionByTargetId.set(target.targetId, attached.sessionId);
+            await client.send('Runtime.enable', {}, attached.sessionId);
+            await client.send('Log.enable', {}, attached.sessionId).catch(() => undefined);
+        } catch {
+            tracking.attachedTargets.add(target.targetId);
+        }
+    }
+}
+
+async function waitForCodeAssetBrowserContext(client, tracking, waitMs = timeoutMs) {
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+        await attachUntrackedTargets(client, tracking);
+        for (const { sessionId, context } of tracking.contexts.values()) {
+            const result = await client.send('Runtime.evaluate', {
+                contextId: context.id,
+                expression: '!!window.__wurstCodeAssetBrowserDebug',
+                returnByValue: true,
+            }, sessionId).catch(() => undefined);
+            if (result?.result?.value) return { sessionId, contextId: context.id };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error('Timed out waiting for the code-launched asset browser webview.');
+}
+
+async function assertCodeAssetBrowserSearch(client, pageSessionId, tracking, userDataDir) {
+    if (!codeAssetFile) {
+        log('code-launched asset-browser check skipped (set WURST_OBJMOD_E2E_CODE_FILE for custom fixtures)');
+        return;
+    }
+    assert.ok(pageSessionId, 'extension-host workbench target should be attached');
+    log('opening code-launched asset browser from a real Wurst CodeLens');
+    await client.send('Page.bringToFront', {}, pageSessionId).catch(() => undefined);
+    bringVsCodeWindowToForeground(userDataDir);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const CTRL = 2;
+    await pressKeyCombo(client, pageSessionId, [
+        { key: 'Control', code: 'ControlLeft', vk: 17, modifiers: CTRL },
+        { key: 'p', code: 'KeyP', vk: 80, modifiers: CTRL },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await typeText(client, pageSessionId, path.basename(codeAssetFile));
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await pressEnter(client, pageSessionId);
+
+    const codeLensExpression = `(function () {
+        return Array.from(document.querySelectorAll('.codelens-decoration, .codelens-decoration a'))
+            .some(function (node) { return String(node.textContent || '').indexOf('Browse model') >= 0; });
+    })()`;
+    await waitForSessionEval(client, pageSessionId, codeLensExpression, (value) => value === true, 'Browse model CodeLens', 15000);
+    const clicked = await evalInSession(client, pageSessionId, `(function () {
+        var node = Array.from(document.querySelectorAll('.codelens-decoration a, .codelens-decoration'))
+            .find(function (candidate) { return String(candidate.textContent || '').indexOf('Browse model') >= 0; });
+        if (!node) return false;
+        node.click();
+        return true;
+    })()`);
+    assert.equal(clicked, true, 'Browse model CodeLens should be clickable');
+
+    const codeBrowser = await waitForCodeAssetBrowserContext(client, tracking, 30000);
+    await evalInContext(client, codeBrowser.sessionId, codeBrowser.contextId, 'window.__wurstCodeAssetBrowserDebug.search("footman")');
+    const state = await waitForEval(
+        client,
+        codeBrowser.sessionId,
+        codeBrowser.contextId,
+        'window.__wurstCodeAssetBrowserDebug.state()',
+        (value) => value && value.query === 'footman' && Array.isArray(value.results) && value.results.length > 0,
+        'code-launched footman asset search results',
+        15000,
+    );
+    assert.equal(state.activeTab, 'model', 'model string CodeLens should open the Models tab');
+    assert.ok(
+        state.results.some((entry) => /footman/i.test(`${entry.label} ${entry.value}`)),
+        `code-launched asset search should return Footman: ${JSON.stringify(state.results)}`,
+    );
+    assert.ok(
+        state.results.every((entry) => /footm[ae]n/i.test(`${entry.label} ${entry.value}`)),
+        `code-launched asset search should not contain unrelated fuzzy noise: ${JSON.stringify(state.results)}`,
+    );
+    for (let i = 1; i < state.results.length; i++) {
+        assert.ok(
+            state.results[i - 1].score <= state.results[i].score,
+            `code-launched asset search scores should be sorted: ${JSON.stringify(state.results)}`,
+        );
+    }
+    log(`code-launched footman search returned ${state.results.length} relevance-sorted results`);
 }
 
 async function assertTooltipFont(client, sessionId, contextId) {
@@ -787,13 +973,14 @@ async function main() {
         WURST_OBJMOD_E2E_PROJECT: projectPath,
         WURST_OBJMOD_E2E_FILE: objmodFile,
     };
+    if (codeOnly) delete childEnv.WURST_OBJMOD_E2E_FILE;
     delete childEnv.ELECTRON_RUN_AS_NODE;
     log(`code=${code}`);
     log(`project=${projectPath}`);
     log(`file=${objmodFile}`);
     log(`devtoolsPort=${devtoolsPort}`);
 
-    const child = spawnCode(code, [
+    const launchArgs = [
         '--new-window',
         '--skip-welcome',
         '--skip-release-notes',
@@ -804,8 +991,9 @@ async function main() {
         `--extensions-dir=${extensionsDir}`,
         `--extensionDevelopmentPath=${root}`,
         projectPath,
-        objmodFile,
-    ], childEnv);
+        codeOnly ? codeAssetFile : objmodFile,
+    ];
+    const child = spawnCode(code, launchArgs, childEnv);
 
     let stderr = '';
     let passed = false;
@@ -829,8 +1017,14 @@ async function main() {
         log('connecting DevTools WebSocket');
         client = new CdpClient(version.webSocketDebuggerUrl);
         await client.connect();
-        log('waiting for objmod webview');
-        const { sessionId, contextId } = await waitForWebviewContext(client);
+        log(codeOnly ? 'waiting for extension-host workbench' : 'waiting for objmod webview');
+        const tracking = await waitForWebviewContext(client, !codeOnly);
+        if (codeOnly) {
+            await assertCodeAssetBrowserSearch(client, tracking.pageSessionId, tracking, userDataDir);
+            passed = true;
+            return;
+        }
+        const { sessionId, contextId, pageSessionId } = tracking;
         log('asserting objmod editor basics');
         await assertObjmodEditorBasics(client, sessionId, contextId);
         if (fontOnly) {
@@ -931,6 +1125,7 @@ async function main() {
                     assert.equal(failures.length, 0, failures.join('\n'));
                     const maxObserved = numbers.length ? `${Math.max(...numbers)}ms` : 'n/a';
                     log(`passed ${initialKeys.length} completed thumbnails, max observed=${maxObserved}`);
+                    await assertCodeAssetBrowserSearch(client, pageSessionId, tracking, userDataDir);
                     passed = true;
                     return;
                 }

--- a/scripts/test-fuzzy.js
+++ b/scripts/test-fuzzy.js
@@ -20,6 +20,16 @@ const { fuzzyMatch, assetSearchScore } = mod.exports;
 assert.strictEqual(typeof fuzzyMatch, 'function', 'fuzzyMatch should be exported');
 assert.strictEqual(typeof assetSearchScore, 'function', 'assetSearchScore should be exported');
 
+// The code-launched asset picker serializes both functions into an isolated webview. This must not
+// leave the scorer reaching back into its original CommonJS/webpack module closure.
+const isolatedFuzzyMatch = new Function(`return (${fuzzyMatch.toString()});`)();
+const isolatedAssetSearchScore = new Function(`return (${assetSearchScore.toString()});`)();
+assert.equal(
+    isolatedAssetSearchScore('footman', 'Footman.mdx', 'units\\human\\Footman.mdx', '', isolatedFuzzyMatch),
+    0,
+    'serialized asset scorer should run with only its explicit fuzzy matcher dependency',
+);
+
 let passed = 0;
 function ok(query, text, expected, msg) {
     const got = fuzzyMatch(query, text);
@@ -67,7 +77,7 @@ const footmanCandidates = [
     { label: 'AltarOfKings - altarofkings', value: 'buildings\\human\\AltarOfKings\\AltarOfKings.mdx' },
 ];
 const footmanResults = footmanCandidates
-    .map((item, index) => ({ ...item, index, score: assetSearchScore('footman', item.label, item.value) }))
+    .map((item, index) => ({ ...item, index, score: assetSearchScore('footman', item.label, item.value, '', fuzzyMatch) }))
     .filter((item) => Number.isFinite(item.score))
     .sort((a, b) => a.score - b.score || a.index - b.index);
 assert.deepStrictEqual(
@@ -80,6 +90,6 @@ assert.deepStrictEqual(
     [0, 10, 20],
     'asset relevance scores should be deterministic',
 );
-passed += 2;
+passed += 3;
 
 console.log(`fuzzy unit tests passed (${passed} assertions)`);

--- a/scripts/test-webview.js
+++ b/scripts/test-webview.js
@@ -222,12 +222,13 @@ function installObjModStateDom(persistedState) {
     const els = { tree: new FakeElement(), details: new FakeElement(), search: new FakeElement() };
     global.document = { getElementById: (id) => els[id] || null };
     let state = persistedState || {};
+    const messages = [];
     global.acquireVsCodeApi = () => ({
-        postMessage: () => {},
+        postMessage: (message) => { messages.push(message); },
         getState: () => state,
         setState: (next) => { state = next; },
     });
-    return { getState: () => state };
+    return { getState: () => state, getMessages: () => messages };
 }
 
 // state.ts is meant to make a reopened editor (a webview reload after our external-change auto-reload
@@ -235,9 +236,13 @@ function installObjModStateDom(persistedState) {
 // a blank slate — see the persistUi effect and the restoredSelectedKey logic there.
 function testObjModStateRestoresAndPersistsUiState() {
     moduleCache.clear();
-    const objects = [{ key: 'Custom:0' }, { key: 'Custom:1' }];
+    const objects = [
+        { key: 'Custom:0', identity: 'Custom:hfoo|h001' },
+        { key: 'Custom:1', identity: 'Custom:hrif|h002' },
+    ];
     const dom = installObjModStateDom({
-        selectedKey: 'Custom:1',
+        selectedKey: 'Custom:0', // deliberately stale after an external reorder
+        selectedIdentity: 'Custom:hrif|h002',
         query: 'foo',
         fieldQuery: 'dmg',
         showTechnical: true,
@@ -270,13 +275,19 @@ function testObjModStateRestoresAndPersistsUiState() {
     assert.equal(persistedAfter.treeScrollTop, 240, 'persisting one field must not drop the others');
     assert.equal(persistedAfter.detailsScrollTop, 150, 'persisting one field must not drop the others');
     assert.equal(persistedAfter.selectedKey, 'Custom:1', 'unrelated restored fields must survive a later persist');
+    assert.equal(persistedAfter.selectedIdentity, 'Custom:hrif|h002', 'selection persistence must use stable rawcodes, not an array index');
+    assert.ok(dom.getMessages().some(message => message.type === 'selectionChanged' && message.identity === 'Custom:hrif|h002'),
+        'the stable selection identity must be sent to the host for workspace-relative persistence');
     assert.equal(persistedAfter.listW, 321, 'fields unrelated to reactive ui state (e.g. splitter width) must not be clobbered');
 }
 
 function testObjModStatePendingJumpOverridesRestoredSelection() {
     moduleCache.clear();
-    const objects = [{ key: 'Custom:0' }, { key: 'Custom:1' }];
-    installObjModStateDom({ selectedKey: 'Custom:1' });
+    const objects = [
+        { key: 'Custom:0', identity: 'Custom:hfoo|h001' },
+        { key: 'Custom:1', identity: 'Custom:hrif|h002' },
+    ];
+    installObjModStateDom({ selectedKey: 'Custom:1', selectedIdentity: 'Custom:hrif|h002' });
     global.window.__OBJMOD_INITIAL__ = { objects, selectedKey: 'Custom:0', isPendingJump: true, extended: false };
 
     const state = loadTsModule('src/webview/objModEditor/state.ts');
@@ -285,8 +296,8 @@ function testObjModStatePendingJumpOverridesRestoredSelection() {
 
 function testObjModStateIgnoresStaleRestoredSelection() {
     moduleCache.clear();
-    const objects = [{ key: 'Custom:0' }]; // 'Custom:99' below no longer exists in this file
-    installObjModStateDom({ selectedKey: 'Custom:99' });
+    const objects = [{ key: 'Custom:0', identity: 'Custom:hfoo|h001' }];
+    installObjModStateDom({ selectedKey: 'Custom:99', selectedIdentity: 'Custom:old0|old1' });
     global.window.__OBJMOD_INITIAL__ = { objects, selectedKey: 'Custom:0', isPendingJump: false, extended: false };
 
     const state = loadTsModule('src/webview/objModEditor/state.ts');
@@ -300,8 +311,8 @@ function testObjModStateIgnoresStaleRestoredSelection() {
 function testObjModTreeRenderPreservesScrollPosition() {
     moduleCache.clear();
     const objects = [
-        { key: 'Custom:0', group: 'Custom', race: 'human', displayName: 'Alpha', baseId: 'a000' },
-        { key: 'Custom:1', group: 'Custom', race: 'human', displayName: 'Beta', baseId: 'b000' },
+        { key: 'Custom:0', identity: 'Custom:a000|a001', group: 'Custom', race: 'human', displayName: 'Alpha', baseId: 'a000' },
+        { key: 'Custom:1', identity: 'Custom:b000|b001', group: 'Custom', race: 'human', displayName: 'Beta', baseId: 'b000' },
     ];
     installObjModStateDom({ treeScrollTop: 240 });
     global.window.__OBJMOD_INITIAL__ = { objects, selectedKey: '', isPendingJump: false, extended: false };
@@ -628,7 +639,7 @@ function testNonBlockingStartupAndForcedReinstallWiring() {
     assert.ok(!extension.includes('ensureInstalledOrOfferMigration(true)'), 'manual install/update must not use the no-op ensure path');
     assert.ok(!languageServer.includes('await maybeOfferUpdate(context)'), 'update checks must not delay language-client startup');
     assert.ok(languageServer.includes('void maybeOfferUpdate((update) =>'), 'update checks should still run in the background and update the status item');
-    assert.ok(languageServer.includes("'$(cloud-download) WurstScript Update'"), 'the status item must indicate when an update is available');
+    assert.ok(languageServer.includes("'$(circle-filled) WurstScript Update'"), 'the status item must indicate when an update is available');
     assert.ok(!installer.includes("{ modal: true, detail }, 'Update', 'Later'"), 'the automatic update notification must not be modal');
     assert.ok(installer.includes("'Update', 'Later'"), 'the non-modal update notification must retain its actions');
     assert.ok(installer.includes("execFile(java, ['-jar', COMPILER_JAR, '--version']"), 'version detection must use an asynchronous child process');
@@ -752,7 +763,7 @@ function testAssetBrowserForwardsModelTextures() {
         'asset browser must not silently drop model texture requests'
     );
     assert.ok(
-        script.includes('assetSearchScore(query, item.label, item.value, item.detail)'),
+        script.includes('assetSearchScore(query, item.label, item.value, item.detail, fuzzyMatch)'),
         'code and object-data asset pickers should share the relevance scorer'
     );
     assert.ok(
@@ -794,7 +805,7 @@ function testThumbnailLifecycleGuards() {
     assert.ok(objmod.includes('fetch(initial.thumbnailWorkerUri'), 'the worker bundle must be fetched before creating its Blob URL');
     assert.ok(!objmod.includes('new Worker(initial.thumbnailWorkerUri)'), 'VS Code resource URLs cannot be passed directly to the Worker constructor');
     assert.ok(assetBrowser.includes('modelThumbEnsureInit()'), 'opening or selecting the model asset browser should prewarm the thumbnail worker');
-    assert.ok(assetBrowser.includes("import { assetSearchScore } from '../../features/preview/fuzzy'"), 'objmod asset search should use the shared relevance scorer');
+    assert.ok(assetBrowser.includes("import { assetSearchScore, fuzzyMatch } from '../../features/preview/fuzzy'"), 'objmod asset search should use the shared relevance scorer');
     const ensureInit = /export function modelThumbEnsureInit\(\) \{([\s\S]*?)\n\}/.exec(objmod)?.[1] || '';
     assert.ok(!ensureInit.includes('mpvViewer()'), 'worker startup failure must not fall back to rendering on the objmod UI thread');
     assert.ok(webpack.includes("mdxThumbnailWorker: './src/webview/mdxThumbnailWorker.ts'"), 'the isolated thumbnail worker must be bundled');
@@ -1017,6 +1028,27 @@ function testObjModEditorTypeAndRecoveryGuards() {
     assert.ok(host.includes('wtsEdits: Array.from(doc.wtsEdits)'), 'objmod backups must include staged WTS edits');
     assert.ok(host.includes('currentRevision = beforeRevision'), 'undo must restore a history identity, not decrement a depth');
     assert.ok(!host.includes('doc.editDepth'), 'branch-unsafe edit depth tracking must not return');
+    assert.ok(host.includes('watcher.onDidDelete(onEvent)'), 'external-change detection must cover Git-style file replacement');
+    assert.ok(host.includes('id="refresh-editor"'), 'the object editor must expose a manual refresh action');
+    assert.ok(host.includes('preferredSelectionIdentity'), 'reloading must resolve selection by stable object identity');
+    assert.ok(host.includes('objModSelectionPathKey(doc.uri)'), 'selection must be stored per workspace-relative document path');
+}
+
+function testWpmEditorInlineScriptAndRecoveryGuards() {
+    const host = fs.readFileSync(path.join(root, 'src/features/wpmPreview.ts'), 'utf8');
+    const match = host.match(/<script>\r?\n([\s\S]*?)\r?\n {2}<\/script>/);
+    assert.ok(match, 'WPM editor inline script should be present');
+    const script = match[1]
+        .replace('${wpm.width}', '4')
+        .replace('${wpm.height}', '4')
+        .replace('${dataBase64}', 'AAAAAAAAAAAAAAAAAAAAAA==')
+        .replace(/\\`/g, '`')
+        .replace(/\\\$\{/g, '${');
+    // eslint-disable-next-line sonarjs/constructor-for-side-effects -- parsing the real inline script is the assertion.
+    new vm.Script(script);
+    assert.ok(host.includes('openContext.backupId'), 'WPM documents must restore VS Code hot-exit backups');
+    assert.ok(host.includes('currentRevision !== doc.savedRevision'), 'WPM dirty tracking must distinguish edit-history branches');
+    assert.ok(!host.includes('doc.editDepth'), 'WPM dirty tracking must not use branch-unsafe edit depth');
 }
 
 async function main() {
@@ -1033,6 +1065,7 @@ async function main() {
     testBc5DdsDecode();
     testInstallerVersionShaParsing();
     testObjModEditorTypeAndRecoveryGuards();
+    testWpmEditorInlineScriptAndRecoveryGuards();
     testNonBlockingStartupAndForcedReinstallWiring();
     testWurstProcessMatching();
     await testModelThumbnailRequestsTexturesByDefault();

--- a/src/features/assetLinks.ts
+++ b/src/features/assetLinks.ts
@@ -299,7 +299,7 @@ ${ICON_INLINE_CSS}
     var items = (initial.tabs[activeTab] || []);
     if (!query) return items.slice(0, 500);
     return items.map(function (item, index) {
-      return { item: item, index: index, score: assetSearchScore(query, item.label, item.value, item.detail) };
+      return { item: item, index: index, score: assetSearchScore(query, item.label, item.value, item.detail, fuzzyMatch) };
     }).filter(function (entry) {
       return Number.isFinite(entry.score);
     }).sort(function (a, b) {
@@ -609,6 +609,26 @@ ${ICON_INLINE_CSS}
       if (!modelJob.pendingTextures || modelJob.pendingTextures.size === 0) scheduleModelCapture(0, 1);
     }
   });
+  window.__wurstCodeAssetBrowserDebug = {
+    search: function (value) {
+      query = String(value || '');
+      document.getElementById('search').value = query;
+      render();
+    },
+    state: function () {
+      return {
+        activeTab: activeTab,
+        query: query,
+        results: list().slice(0, 50).map(function (item) {
+          return {
+            label: item.label,
+            value: item.value,
+            score: assetSearchScore(query, item.label, item.value, item.detail, fuzzyMatch)
+          };
+        })
+      };
+    }
+  };
   render();
   document.getElementById('search').focus();
 })();

--- a/src/features/objModPreview.ts
+++ b/src/features/objModPreview.ts
@@ -144,6 +144,8 @@ const OBJ_EDITOR_CONFIG: Record<string, { metaPath: string; profilePaths: string
 
 interface PreviewObject {
     key: string;
+    /** Stable across file rewrites/reordering; unlike key, this does not contain an array index. */
+    identity: string;
     group: 'Original' | 'Custom';
     baseId: string;
     newId: string | null;
@@ -258,6 +260,14 @@ const openObjModDocuments = new Map<string, ObjModDocument>();
 /** Object key to select once a given uri's editor finishes loading — set right before
  *  `vscode.openWith` opens (or reveals) that file for a cross-reference jump. */
 const pendingObjectSelection = new Map<string, string>();
+const OBJMOD_SELECTIONS_STATE_KEY = 'wurst.objModSelectionsByRelativePath.v1';
+
+function objModSelectionPathKey(uri: vscode.Uri): string {
+    const folder = vscode.workspace.getWorkspaceFolder(uri);
+    if (!folder || uri.scheme !== 'file') return uri.toString();
+    const relative = path.relative(folder.uri.fsPath, uri.fsPath).replace(/\\/g, '/');
+    return `${folder.uri.toString()}::${relative}`;
+}
 
 const CATALOG_EXTS = ['.w3u', '.w3t', '.w3a', '.w3b', '.w3d', '.w3h', '.w3q'];
 const RACE_OPTIONS: ValueOption[] = [
@@ -466,6 +476,7 @@ function buildObject(
 
     return {
         key: `${group}:${index}`,
+        identity: `${group}:${entryKey(entry)}`,
         group,
         baseId: entry.baseId,
         newId: entry.newId,
@@ -1664,6 +1675,7 @@ async function buildHtml(
     objModEditorUri?: string,
     thumbnailWorkerUri?: string,
     combined?: CombinedObjModInfo,
+    preferredSelectionIdentity?: string,
 ): Promise<string> {
     const typeLabel = TYPE_LABELS[parsed.ext.slice(1)] ?? parsed.ext.slice(1).toUpperCase();
     const triggerStrings = loadTriggerStringsForUri(context.uri);
@@ -1680,9 +1692,10 @@ async function buildHtml(
     // override a restored last-session selection, which should otherwise win over the plain fallback).
     const pendingKey = pendingObjectSelection.get(context.uri.toString());
     if (pendingKey) pendingObjectSelection.delete(context.uri.toString());
+    const preferredKey = objects.find((object) => object.identity === preferredSelectionIdentity)?.key;
     const initialJson = JSON.stringify({
         objects,
-        selectedKey: pendingKey ?? objects[0]?.key ?? '',
+        selectedKey: pendingKey ?? preferredKey ?? objects[0]?.key ?? '',
         isPendingJump: !!pendingKey,
         extended: parsed.extended,
         fileInfo: combined ?? { mainName: fileName },
@@ -1887,6 +1900,19 @@ body.density-cozy #density-toggle { margin-left: auto; }
   color: var(--vscode-editorWarning-foreground, #cca700);
 }
 .editable-badge.dirty:hover { background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 12%, transparent); }
+.refresh-button {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+.refresh-button:hover { background: var(--hover); color: var(--fg); }
+.refresh-button:focus-visible { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: 1px; }
 /* Same pill shape as the save badge, but a neutral (non-accent) affordance — it's a view preference,
    not document state. */
 .density-toggle {
@@ -3084,6 +3110,7 @@ ${tooltipFontCss}
     <span class="density-track" aria-hidden="true"><span class="density-thumb"></span></span>
     <span class="density-option density-option-cozy">Spacious</span>
   </button>
+  <button type="button" id="refresh-editor" class="refresh-button" title="Reload this object file from disk">↻ Refresh</button>
   <button type="button" id="editable-badge" class="editable-badge" title="Existing overrides can be edited. Click or Ctrl+S to save.">editable</button>
 </div>
 ${errorBanner}
@@ -3483,6 +3510,8 @@ class ObjModDocument implements vscode.CustomDocument {
     /** Coalesces bursts of fs-watcher events (e.g. a `git pull` touching main+skin+wts together) into
         one combined check instead of one prompt per file. */
     externalChangeDebounce: ReturnType<typeof setTimeout> | undefined;
+    /** Stable rawcode identity last selected for this workspace-relative document path. */
+    selectedIdentity: string | undefined;
 
     constructor(
         readonly uri: vscode.Uri,
@@ -3589,11 +3618,15 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
     private readonly _onDidChange = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<ObjModDocument>>();
     readonly onDidChangeCustomDocument = this._onDidChange.event;
 
-    constructor(private readonly extensionUri: vscode.Uri) {}
+    constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly workspaceState: vscode.Memento,
+    ) {}
 
     async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<ObjModDocument> {
         if (openContext.backupId) {
             const restored = await openObjModBackup(uri, openContext.backupId);
+            restored.selectedIdentity = this.storedSelection(uri);
             await this.snapshotKnownBytes(restored);
             return restored;
         }
@@ -3602,6 +3635,7 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
         const { uri: wtsUri, exists } = findWtsUri(uri);
         const wtsWarning = computeWtsWarning(e.displayFile, exists);
         const doc = new ObjModDocument(uri, e.mainFile, e.mainUri, e.skinFile, e.skinUri, e.displayFile, wtsTable, wtsUri, exists, wtsWarning);
+        doc.selectedIdentity = this.storedSelection(uri);
         await this.snapshotKnownBytes(doc);
         return doc;
     }
@@ -3621,7 +3655,8 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
         doc.panelWebview = panel.webview;
         doc.panel = panel;
         openObjModDocuments.set(doc.mainUri.toString(), doc);
-        this.watchExternalChanges(doc, panel);
+        this.watchExternalChanges(doc);
+        panel.onDidDispose(() => doc.disposeWatchers());
         const mdxViewerUri = panel.webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview', 'mdxViewer.js'),
         ).toString();
@@ -3643,6 +3678,7 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
                 objModEditorUri,
                 thumbnailWorkerUri,
                 doc.combinedInfo,
+                doc.selectedIdentity,
             );
         };
 
@@ -3670,6 +3706,7 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
             cacheKey?: string; aliasKey?: string; webpBase64?: string; thumbKey?: string; phase?: string; elapsedMs?: number; deltaMs?: number; detail?: string;
             fieldId?: string; varType?: string; level?: number | null; dataPt?: number | null; value?: string;
             rawcode?: string; label?: string;
+            identity?: string;
         };
         if (msg.type === 'loadObjectDetails' && msg.key) {
             await loadObjectDetails(msg.key, webview, doc);
@@ -3748,6 +3785,14 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
             }
             return;
         }
+        if (msg.type === 'selectionChanged' && msg.identity) {
+            this.rememberSelection(doc, msg.identity);
+            return;
+        }
+        if (msg.type === 'refresh') {
+            await this.refreshFromDisk(doc);
+            return;
+        }
         if (msg.type === 'undo') { void vscode.commands.executeCommand('undo'); return; }
         if (msg.type === 'redo') { void vscode.commands.executeCommand('redo'); return; }
         if (msg.type === 'save') { void vscode.commands.executeCommand('workbench.action.files.save'); return; }
@@ -3789,6 +3834,18 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
 
     private postDirtyState(doc: ObjModDocument): void {
         void doc.panelWebview?.postMessage({ type: 'dirtyStateChanged', isDirty: doc.currentRevision !== doc.savedRevision });
+    }
+
+    private storedSelection(uri: vscode.Uri): string | undefined {
+        return this.workspaceState.get<Record<string, string>>(OBJMOD_SELECTIONS_STATE_KEY)?.[objModSelectionPathKey(uri)];
+    }
+
+    private rememberSelection(doc: ObjModDocument, identity: string): void {
+        if (doc.selectedIdentity === identity) return;
+        doc.selectedIdentity = identity;
+        const selections = { ...(this.workspaceState.get<Record<string, string>>(OBJMOD_SELECTIONS_STATE_KEY) ?? {}) };
+        selections[objModSelectionPathKey(doc.uri)] = identity;
+        void this.workspaceState.update(OBJMOD_SELECTIONS_STATE_KEY, selections);
     }
 
     /** A rawcode chip (e.g. an ability on a unit) that isn't overridden in the currently open file —
@@ -3914,8 +3971,24 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
         const { exists } = findWtsUri(doc.uri);
         doc.wtsExists = exists;
         doc.wtsWarning = computeWtsWarning(doc.displayFile, exists);
-        if (doc.reload) await doc.reload();
+        this.watchExternalChanges(doc);
         await this.snapshotKnownBytes(doc);
+        if (doc.reload) await doc.reload();
+    }
+
+    private async refreshFromDisk(doc: ObjModDocument): Promise<void> {
+        if (doc.currentRevision !== doc.savedRevision) {
+            const choice = await vscode.window.showWarningMessage(
+                `${uriBaseName(doc.mainUri)} has unsaved changes. Refreshing will discard your edits.`,
+                'Discard Edits and Refresh',
+            );
+            if (choice !== 'Discard Edits and Refresh') return;
+            doc.panel?.reveal();
+            await vscode.commands.executeCommand('workbench.action.files.revert');
+        } else {
+            await this.reloadDocFromDisk(doc);
+        }
+        vscode.window.setStatusBarMessage(`$(sync) Refreshed ${uriBaseName(doc.mainUri)} from disk.`, 4000);
     }
 
     /** Records the bytes currently on disk for every file this document watches, so a later fs-watcher
@@ -3935,7 +4008,8 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
     /** Watches this document's main/skin/wts files for changes made outside this editor (another
      *  editor, `git pull`, a teammate's overwrite) and reacts once bytes on disk actually differ from
      *  what we last read/wrote — see checkExternalChange for what happens once one is confirmed. */
-    private watchExternalChanges(doc: ObjModDocument, panel: vscode.WebviewPanel): void {
+    private watchExternalChanges(doc: ObjModDocument): void {
+        doc.disposeWatchers();
         for (const uri of watchedUris(doc)) {
             const watcher = vscode.workspace.createFileSystemWatcher(
                 new vscode.RelativePattern(vscode.Uri.joinPath(uri, '..'), uriBaseName(uri)),
@@ -3943,15 +4017,22 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
             const onEvent = () => this.scheduleExternalChangeCheck(doc);
             watcher.onDidChange(onEvent);
             watcher.onDidCreate(onEvent); // war3map.wts may not have existed yet when this document opened
+            watcher.onDidDelete(onEvent); // Git commonly replaces files through delete/rename/create sequences
             doc.watcherDisposables.push(watcher);
         }
-        panel.onDidDispose(() => doc.disposeWatchers());
     }
 
     // Coalesces a burst of fs events (main+skin+wts all touched by the same `git pull`) into one check.
     private scheduleExternalChangeCheck(doc: ObjModDocument): void {
         if (doc.externalChangeDebounce) clearTimeout(doc.externalChangeDebounce);
-        doc.externalChangeDebounce = setTimeout(() => { void this.checkExternalChange(doc); }, 400);
+        doc.externalChangeDebounce = setTimeout(() => {
+            void this.checkExternalChange(doc).catch((err) => {
+                void showWarningWithLogs(
+                    `Could not refresh ${uriBaseName(doc.mainUri)} after it changed on disk. Use Refresh to try again.`,
+                    err,
+                );
+            });
+        }, 400);
     }
 
     private async checkExternalChange(doc: ObjModDocument): Promise<void> {
@@ -4050,7 +4131,7 @@ async function writeBytesIfChanged(bytes: Buffer, uri: vscode.Uri): Promise<Buff
 export function registerObjModPreview(context: vscode.ExtensionContext): vscode.Disposable {
     return vscode.window.registerCustomEditorProvider(
         'wurst.objModPreview',
-        new ObjModEditorProvider(context.extensionUri),
+        new ObjModEditorProvider(context.extensionUri, context.workspaceState),
         {
             supportsMultipleEditorsPerDocument: false,
             webviewOptions: { retainContextWhenHidden: true },

--- a/src/features/preview/fuzzy.ts
+++ b/src/features/preview/fuzzy.ts
@@ -48,11 +48,19 @@ export function fuzzyMatch(query: string, text: string): boolean {
 /**
  * Relevance score for asset-picker entries. Lower is better; Infinity means no match.
  *
- * Keep this dependency-free and reference only `fuzzyMatch`: the code-asset picker ships both
- * functions into its webview with `.toString()`. Search individual fields instead of one joined
- * haystack so a query cannot be assembled from unrelated letters across a label, path, and detail.
+ * Keep this dependency-free: the code-asset picker ships this function into its webview with
+ * `.toString()`. Its fuzzy matcher is an explicit argument because a bundled function's source
+ * cannot safely refer back to another symbol in the extension module. Search individual fields
+ * instead of one joined haystack so a query cannot be assembled from unrelated letters across a
+ * label, path, and detail.
  */
-export function assetSearchScore(query: string, label: string, value: string, detail = ''): number {
+export function assetSearchScore(
+    query: string,
+    label: string,
+    value: string,
+    detail: string,
+    matchesFuzzy: (needle: string, haystack: string) => boolean,
+): number {
     const q = String(query === null || query === undefined ? '' : query).toLowerCase().trim();
     if (!q) return 0;
 
@@ -71,6 +79,6 @@ export function assetSearchScore(query: string, label: string, value: string, de
     if (labelWords.includes(q)) return 30;
     if (valueWords.includes(q)) return 40;
     if (String(detail === null || detail === undefined ? '' : detail).toLowerCase().includes(q)) return 50;
-    if (fuzzyMatch(q, labelStem) || fuzzyMatch(q, stem)) return 80;
+    if (matchesFuzzy(q, labelStem) || matchesFuzzy(q, stem)) return 80;
     return Number.POSITIVE_INFINITY;
 }

--- a/src/features/wpmPreview.ts
+++ b/src/features/wpmPreview.ts
@@ -3,15 +3,15 @@
 /** VS Code preview for WC3 war3map.wpm (pathing). Parser lives in `casc-ts/formats`. */
 
 import * as vscode from 'vscode';
-import { parseWpm, WpmFile } from 'casc-ts/formats';
-import { registerParsedPreviewer } from './preview/framework';
+import { parseWpm, serializeWpm, WpmFile } from 'casc-ts/formats';
+import { showErrorWithLogs } from './diagnostics';
 import { buildPage } from './webviewShared';
 import { escapeHtml } from './webviewUtils';
 export { WpmFile } from 'casc-ts/formats';
 
 // ── HTML Rendering ────────────────────────────────────────────────────────────
 
-function buildWpmHtml(wpm: WpmFile, fileName: string): string {
+function buildWpmHtml(wpm: WpmFile, fileName: string, isDirty: boolean): string {
     const dataBase64 = wpm.data.toString('base64');
 
     // Color formula — must stay in sync with the ImageData loop in the <script>.
@@ -97,6 +97,9 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
     padding: 3px 8px; border-radius: 3px; cursor: pointer; font-size: 12px;
   }
   button:hover { background: color-mix(in srgb, var(--btn-bg) 55%, transparent); color: var(--text); }
+  button.active { background: var(--btn-bg); color: var(--btn-fg); }
+  button:focus-visible, input:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; }
+  .dirty { color: var(--vscode-charts-orange); font-size: 11px; }
   #zoomLabel { min-width: 56px; text-align: center; color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; }
   #viewport {
     flex: 1; overflow: hidden; position: relative;
@@ -114,6 +117,13 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
     padding: 8px 12px 10px; border-top: 1px solid var(--border);
     background: var(--panel); flex-shrink: 0;
   }
+  .editbar { display: flex; align-items: center; flex-wrap: wrap; gap: 5px 10px; margin-bottom: 9px; }
+  .editbar .tools { display: flex; gap: 2px; }
+  .brush-flags { display: flex; align-items: center; flex-wrap: wrap; gap: 5px 10px; }
+  .brush-flags label { display: flex; align-items: center; gap: 4px; white-space: nowrap; font-size: 11px; }
+  .brush-flags input { margin: 0; }
+  #brushValue { color: var(--muted); font: 11px var(--vscode-editor-font-family); min-width: 38px; }
+  .edit-hint { color: var(--muted); font-size: 10px; margin-left: auto; }
   .legend-section { margin-bottom: 6px; }
   .legend-heading { font-size: 10px; color: var(--muted); margin-bottom: 5px; text-transform: uppercase; letter-spacing: 0.05em; }
   .legend-note { font-size: 10px; color: var(--muted); text-transform: none; letter-spacing: 0; opacity: 0.75; }
@@ -126,6 +136,7 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
   <header>
     <span class="title">${escapeHtml(fileName)}</span>
     <span class="meta">${wpm.width} × ${wpm.height} &nbsp;·&nbsp; v${wpm.version}</span>
+    <span id="dirtyBadge" class="dirty"${isDirty ? '' : ' hidden'}>Modified</span>
     <div class="toolbar">
       <button id="btnZoomOut" title="Zoom out">−</button>
       <span id="zoomLabel">–</span>
@@ -141,10 +152,31 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
   <div id="tooltip"></div>
 
   <footer>
+    <div class="editbar">
+      <div class="tools">
+        <button type="button" data-tool="pan" class="active" title="Drag to move around the map">Pan</button>
+        <button type="button" data-tool="paint" title="Add or replace pathing flags">Paint</button>
+        <button type="button" data-tool="erase" title="Delete pathing flags from cells">Erase</button>
+      </div>
+      <div class="sep"></div>
+      <div class="brush-flags" title="Flags written by the Paint tool">
+        <label title="Reserved bit 0x01"><input type="checkbox" data-brush-bit="1"> 0x01</label>
+        <label><input type="checkbox" data-brush-bit="2" checked> No Walk</label>
+        <label><input type="checkbox" data-brush-bit="4"> No Fly</label>
+        <label><input type="checkbox" data-brush-bit="8" checked> No Build</label>
+        <label title="Reserved bit 0x10"><input type="checkbox" data-brush-bit="16"> 0x10</label>
+        <label><input type="checkbox" data-brush-bit="32"> Blight</label>
+        <label><input type="checkbox" data-brush-bit="64"> No Water</label>
+        <label><input type="checkbox" data-brush-bit="128"> Unknown</label>
+        <span id="brushValue">0x0A</span>
+      </div>
+      <span class="edit-hint">Each drag is one undo step · Alt+click picks a cell</span>
+    </div>
     ${legendHtml}
   </footer>
 
   <script>
+    const api = acquireVsCodeApi();
     const W = ${wpm.width};
     const H = ${wpm.height};
     const raw = atob("${dataBase64}");
@@ -156,20 +188,19 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
     const viewport  = document.getElementById('viewport');
     const zoomLabel = document.getElementById('zoomLabel');
 
-    // ── Render map into offscreen ImageData once ───────────────────────────────
-    // Direct pixel writes — vastly faster than fillRect per cell.
-    // After this, the offscreen canvas is treated as a static image.
+    // ── Render map into offscreen ImageData ────────────────────────────────────
     const offscreen = document.createElement('canvas');
     offscreen.width = W; offscreen.height = H;
     const offCtx = offscreen.getContext('2d');
     const img = offCtx.createImageData(W, H);
     const px  = img.data;
-    for (let dataY = 0; dataY < H; dataY++) {
-      const dispY = H - 1 - dataY; // WC3 row 0 = bottom of map, flip for screen
-      for (let x = 0; x < W; x++) {
-        const flag = data[dataY * W + x];
+    function writePixel(index) {
+        const dataY = Math.floor(index / W);
+        const x = index % W;
+        const dispY = H - 1 - dataY; // WC3 row 0 = bottom of map, flip for screen
+        const flag = data[index];
         const i = (dispY * W + x) * 4;
-        if (flag === 0) { px[i+3] = 0; continue; }
+        if (flag === 0) { px[i] = 0; px[i+1] = 0; px[i+2] = 0; px[i+3] = 0; return; }
         let r = (flag & 0x02) ? 255 : 0;   // No Walk  → red
         let g = (flag & 0x04) ? 255 : 0;   // No Fly   → green
         let b = (flag & 0x08) ? 255 : 0;   // No Build → blue
@@ -177,15 +208,21 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
         if (flag & 0x40) { r =  r      >>1; g = (g+140)>>1; b = (b+220)>>1; } // No Water → teal blend
         if (flag & 0x80) { r = (r+110)>>1; g = (g+110)>>1; b = (b+110)>>1; } // Unknown  → gray blend
         px[i]=r; px[i+1]=g; px[i+2]=b; px[i+3]=230;
-      }
     }
+    for (let index = 0; index < data.length; index++) writePixel(index);
     offCtx.putImageData(img, 0, 0);
 
     // ── Camera state ───────────────────────────────────────────────────────────
     // camX/camY: which offscreen pixel is at the screen centre (float)
     // zoom: screen pixels per map cell (float, stepless)
-    let camX = W / 2, camY = H / 2, zoom = 1;
+    const savedState = api.getState() || {};
+    let camX = Number.isFinite(savedState.camX) ? savedState.camX : W / 2;
+    let camY = Number.isFinite(savedState.camY) ? savedState.camY : H / 2;
+    let zoom = Number.isFinite(savedState.zoom) ? savedState.zoom : 1;
+    let tool = ['pan', 'paint', 'erase'].includes(savedState.tool) ? savedState.tool : 'pan';
     const MIN_ZOOM = 0.05, MAX_ZOOM = 64;
+
+    function persistView() { api.setState({ camX, camY, zoom, tool }); }
 
     function clampCam() {
       const vw = canvas.width, vh = canvas.height;
@@ -239,6 +276,13 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
         : (zoom * 100).toFixed(0) + '%';
     }
 
+    function refreshCell(index) {
+      writePixel(index);
+      const dataY = Math.floor(index / W);
+      const dispY = H - 1 - dataY;
+      offCtx.putImageData(img, 0, 0, index % W, dispY, 1, 1);
+    }
+
     let rafId = null;
     function scheduleDraw() {
       if (rafId) return;
@@ -272,12 +316,85 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
       camX = mapX - (sx - vw / 2) / zoom;
       camY = mapY - (sy - vh / 2) / zoom;
       clampCam();
+      persistView();
       scheduleDraw();
     }, { passive: false });
 
-    // ── Drag to pan ────────────────────────────────────────────────────────────
-    let dragging = false, dragSX = 0, dragSY = 0, dragCamX = 0, dragCamY = 0;
+    // ── Pan and cell editing ───────────────────────────────────────────────────
+    let dragging = false, editing = false, dragSX = 0, dragSY = 0, dragCamX = 0, dragCamY = 0;
+    let gestureChanges = new Map(), lastEditX = -1, lastEditY = -1;
+
+    function eventCell(e) {
+      const rect = viewport.getBoundingClientRect();
+      const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+      const offX = Math.floor(camX + (sx - canvas.width / 2) / zoom);
+      const offY = Math.floor(camY + (sy - canvas.height / 2) / zoom);
+      const dataY = H - 1 - offY;
+      if (offX < 0 || offX >= W || dataY < 0 || dataY >= H) return null;
+      return { x: offX, y: dataY, index: dataY * W + offX };
+    }
+
+    function brushValue() {
+      let value = 0;
+      document.querySelectorAll('[data-brush-bit]:checked').forEach((input) => { value |= Number(input.dataset.brushBit); });
+      return value;
+    }
+
+    function updateBrushValue() {
+      document.getElementById('brushValue').textContent = '0x' + brushValue().toString(16).padStart(2, '0').toUpperCase();
+    }
+
+    function pickBrush(value) {
+      document.querySelectorAll('[data-brush-bit]').forEach((input) => { input.checked = (value & Number(input.dataset.brushBit)) !== 0; });
+      updateBrushValue();
+      setTool('paint');
+    }
+
+    function editCell(x, y) {
+      if (x < 0 || x >= W || y < 0 || y >= H) return;
+      const index = y * W + x;
+      const next = tool === 'erase' ? 0 : brushValue();
+      if (!gestureChanges.has(index)) gestureChanges.set(index, data[index]);
+      data[index] = next;
+      refreshCell(index);
+    }
+
+    function editLine(fromX, fromY, toX, toY) {
+      const dx = Math.abs(toX - fromX), sx = fromX < toX ? 1 : -1;
+      const dy = -Math.abs(toY - fromY), sy = fromY < toY ? 1 : -1;
+      let x = fromX, y = fromY, err = dx + dy;
+      while (true) {
+        editCell(x, y);
+        if (x === toX && y === toY) break;
+        const twice = 2 * err;
+        if (twice >= dy) { err += dy; x += sx; }
+        if (twice <= dx) { err += dx; y += sy; }
+      }
+      scheduleDraw();
+    }
+
+    function finishEdit() {
+      if (!editing) return;
+      editing = false;
+      const changes = [];
+      gestureChanges.forEach((before, index) => {
+        const value = data[index];
+        if (value !== before) changes.push({ index, value });
+      });
+      gestureChanges = new Map();
+      if (changes.length) api.postMessage({ type: 'editCells', changes });
+    }
+
     viewport.addEventListener('pointerdown', (e) => {
+      const cell = eventCell(e);
+      if (e.button === 0 && e.altKey && cell) { pickBrush(data[cell.index]); return; }
+      if (tool !== 'pan' && e.button === 0 && cell) {
+        editing = true; gestureChanges = new Map(); lastEditX = cell.x; lastEditY = cell.y;
+        viewport.setPointerCapture(e.pointerId);
+        editCell(cell.x, cell.y); scheduleDraw();
+        return;
+      }
+      if (e.button !== 0 && e.button !== 1) return;
       dragging = true;
       dragSX = e.clientX; dragSY = e.clientY;
       dragCamX = camX;    dragCamY = camY;
@@ -285,26 +402,43 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
       viewport.style.cursor = 'grabbing';
     });
     viewport.addEventListener('pointermove', (e) => {
+      if (editing) {
+        const cell = eventCell(e);
+        if (cell && (cell.x !== lastEditX || cell.y !== lastEditY)) {
+          editLine(lastEditX, lastEditY, cell.x, cell.y);
+          lastEditX = cell.x; lastEditY = cell.y;
+        }
+        return;
+      }
       if (!dragging) return;
       camX = dragCamX - (e.clientX - dragSX) / zoom;
       camY = dragCamY - (e.clientY - dragSY) / zoom;
       clampCam();
       scheduleDraw();
     });
-    const endDrag = () => { dragging = false; viewport.style.cursor = 'crosshair'; };
+    const endDrag = () => { finishEdit(); dragging = false; persistView(); viewport.style.cursor = tool === 'pan' ? 'grab' : 'crosshair'; };
     viewport.addEventListener('pointerup',     endDrag);
     viewport.addEventListener('pointercancel', endDrag);
 
     // ── Toolbar buttons ────────────────────────────────────────────────────────
     document.getElementById('btnZoomIn').addEventListener('click', () => {
-      zoom = Math.min(MAX_ZOOM, zoom * 1.5); scheduleDraw();
+      zoom = Math.min(MAX_ZOOM, zoom * 1.5); persistView(); scheduleDraw();
     });
     document.getElementById('btnZoomOut').addEventListener('click', () => {
-      zoom = Math.max(MIN_ZOOM, zoom / 1.5); scheduleDraw();
+      zoom = Math.max(MIN_ZOOM, zoom / 1.5); persistView(); scheduleDraw();
     });
     document.getElementById('btnZoomFit').addEventListener('click', () => {
-      fitToView(); scheduleDraw();
+      fitToView(); persistView(); scheduleDraw();
     });
+
+    function setTool(next) {
+      tool = next;
+      document.querySelectorAll('[data-tool]').forEach((button) => button.classList.toggle('active', button.dataset.tool === tool));
+      viewport.style.cursor = tool === 'pan' ? 'grab' : 'crosshair';
+      persistView();
+    }
+    document.querySelectorAll('[data-tool]').forEach((button) => button.addEventListener('click', () => setTool(button.dataset.tool)));
+    document.querySelectorAll('[data-brush-bit]').forEach((input) => input.addEventListener('change', updateBrushValue));
 
     // ── Tooltip ────────────────────────────────────────────────────────────────
     const tooltip = document.getElementById('tooltip');
@@ -337,34 +471,201 @@ function buildWpmHtml(wpm: WpmFile, fileName: string): string {
     });
     viewport.addEventListener('mouseleave', () => tooltip.style.display = 'none');
 
+    window.addEventListener('message', (event) => {
+      const message = event.data || {};
+      if (message.type === 'applyCells' && Array.isArray(message.changes)) {
+        message.changes.forEach((change) => {
+          if (Number.isInteger(change.index) && change.index >= 0 && change.index < data.length) {
+            data[change.index] = change.value & 0xff;
+            refreshCell(change.index);
+          }
+        });
+        scheduleDraw();
+      } else if (message.type === 'dirtyStateChanged') {
+        document.getElementById('dirtyBadge').hidden = !message.isDirty;
+      }
+    });
+
     // Init: size canvas then fit map
     resizeCanvas();
-    fitToView();
+    if (!Number.isFinite(savedState.zoom)) fitToView();
+    setTool(tool);
+    updateBrushValue();
     draw();
   </script>
 </body>
 </html>`;
 }
 
+// ── Editable document ─────────────────────────────────────────────────────────
+
+class WpmDocument implements vscode.CustomDocument {
+    currentRevision = 0;
+    savedRevision = 0;
+    nextRevision = 1;
+    webview?: vscode.Webview;
+
+    constructor(readonly uri: vscode.Uri, public file: WpmFile) {}
+
+    dispose(): void {}
+}
+
+interface WpmCellChange {
+    index: number;
+    before: number;
+    after: number;
+}
+
+class WpmEditorProvider implements vscode.CustomEditorProvider<WpmDocument> {
+    private readonly _onDidChange = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<WpmDocument>>();
+    readonly onDidChangeCustomDocument = this._onDidChange.event;
+
+    async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<WpmDocument> {
+        const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
+        const doc = new WpmDocument(uri, parseWpm(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        if (openContext.backupId) {
+            doc.currentRevision = 1;
+            doc.nextRevision = 2;
+        }
+        return doc;
+    }
+
+    async resolveCustomEditor(doc: WpmDocument, panel: vscode.WebviewPanel): Promise<void> {
+        panel.webview.options = { enableScripts: true, localResourceRoots: [] };
+        doc.webview = panel.webview;
+        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
+        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
+        this.render(doc, panel.webview);
+    }
+
+    private render(doc: WpmDocument, webview: vscode.Webview): void {
+        const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);
+        webview.html = doc.file.error
+            ? buildPage({
+                csp: "default-src 'none'; style-src 'unsafe-inline';",
+                title: escapeHtml(fileName),
+                body: `<div class="wv-state">
+  <span>Failed to parse WPM</span>
+  <span class="err">${escapeHtml(doc.file.error)}</span>
+</div>`,
+            })
+            : buildWpmHtml(doc.file, fileName, doc.currentRevision !== doc.savedRevision);
+    }
+
+    private handleMessage(message: unknown, doc: WpmDocument): void {
+        if (!message || typeof message !== 'object') return;
+        const msg = message as { type?: string; changes?: Array<{ index?: number; value?: number }> };
+        if (msg.type !== 'editCells' || !Array.isArray(msg.changes)) return;
+
+        const requested = new Map<number, number>();
+        for (const change of msg.changes) {
+            if (Number.isInteger(change.index) && Number.isInteger(change.value) &&
+                (change.index as number) >= 0 && (change.index as number) < doc.file.data.length &&
+                (change.value as number) >= 0 && (change.value as number) <= 0xff) {
+                requested.set(change.index as number, change.value as number);
+            }
+        }
+        const changes: WpmCellChange[] = [];
+        requested.forEach((after, index) => {
+            const before = doc.file.data[index];
+            if (after !== before) changes.push({ index, before, after });
+        });
+        if (!changes.length) return;
+
+        const beforeRevision = doc.currentRevision;
+        const afterRevision = doc.nextRevision++;
+        this.applyCells(doc, changes, false);
+        doc.currentRevision = afterRevision;
+        this.postDirtyState(doc);
+        this._onDidChange.fire({
+            document: doc,
+            label: `${changes.every((change) => change.after === 0) ? 'Erase' : 'Paint'} ${changes.length} pathing cell${changes.length === 1 ? '' : 's'}`,
+            undo: () => {
+                this.applyCells(doc, changes, true);
+                doc.currentRevision = beforeRevision;
+                this.postDirtyState(doc);
+            },
+            redo: () => {
+                this.applyCells(doc, changes, false);
+                doc.currentRevision = afterRevision;
+                this.postDirtyState(doc);
+            },
+        });
+    }
+
+    private applyCells(doc: WpmDocument, changes: WpmCellChange[], useBefore: boolean): void {
+        const patches = changes.map((change) => {
+            const value = useBefore ? change.before : change.after;
+            doc.file.data[change.index] = value;
+            return { index: change.index, value };
+        });
+        void doc.webview?.postMessage({ type: 'applyCells', changes: patches });
+    }
+
+    private postDirtyState(doc: WpmDocument): void {
+        void doc.webview?.postMessage({ type: 'dirtyStateChanged', isDirty: doc.currentRevision !== doc.savedRevision });
+    }
+
+    async saveCustomDocument(doc: WpmDocument): Promise<void> {
+        try {
+            await this.writeWpm(doc, doc.uri);
+            doc.savedRevision = doc.currentRevision;
+            this.postDirtyState(doc);
+        } catch (err) {
+            void showErrorWithLogs(`Pathing map not saved: ${err instanceof Error ? err.message : String(err)}`, err);
+            throw err;
+        }
+    }
+
+    async saveCustomDocumentAs(doc: WpmDocument, target: vscode.Uri): Promise<void> {
+        await vscode.workspace.fs.writeFile(target, serializeValidatedWpm(doc.file, target.path));
+    }
+
+    private async writeWpm(doc: WpmDocument, uri: vscode.Uri): Promise<void> {
+        const bytes = serializeValidatedWpm(doc.file, uri.path);
+        try {
+            const existing = Buffer.from(await vscode.workspace.fs.readFile(uri));
+            if (existing.equals(bytes)) return;
+        } catch { /* missing → write */ }
+        await vscode.workspace.fs.writeFile(uri, bytes);
+    }
+
+    async revertCustomDocument(doc: WpmDocument): Promise<void> {
+        doc.file = parseWpm(Buffer.from(await vscode.workspace.fs.readFile(doc.uri)));
+        doc.currentRevision = 0;
+        doc.savedRevision = 0;
+        doc.nextRevision = 1;
+        if (doc.webview) this.render(doc, doc.webview);
+    }
+
+    async backupCustomDocument(doc: WpmDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> {
+        await vscode.workspace.fs.writeFile(context.destination, serializeValidatedWpm(doc.file, doc.uri.path));
+        return {
+            id: context.destination.toString(),
+            delete: () => vscode.workspace.fs.delete(context.destination).then(() => undefined, () => undefined),
+        };
+    }
+}
+
+/** Safety gate: never write a WPM that does not reproduce the complete edited grid. */
+function serializeValidatedWpm(file: WpmFile, name: string): Buffer {
+    if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
+    const bytes = serializeWpm(file);
+    const reparsed = parseWpm(bytes);
+    if (reparsed.error) throw new Error(`Refusing to save ${name}: serialized data did not re-parse (${reparsed.error}).`);
+    if (reparsed.version !== file.version || reparsed.width !== file.width || reparsed.height !== file.height ||
+        !reparsed.data.equals(file.data) || !reparsed.tail?.equals(file.tail ?? Buffer.alloc(0))) {
+        throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    }
+    return bytes;
+}
+
 // ── Registration ──────────────────────────────────────────────────────────────
 
 export function registerWpmPreview(_context: vscode.ExtensionContext): vscode.Disposable[] {
-    return [
-        registerParsedPreviewer<WpmFile>({
-            viewType: 'wurst.wpmPreview',
-            parse:  (data) => parseWpm(data),
-            render: (parsed, fileName) => parsed.error
-                ? buildPage({
-                    csp: "default-src 'none'; style-src 'unsafe-inline';",
-                    title: escapeHtml(fileName),
-                    body: `<div class="wv-state">
-  <span>Failed to parse WPM</span>
-  <span class="err">${escapeHtml(parsed.error)}</span>
-</div>`,
-                })
-                : buildWpmHtml(parsed, fileName),
-            webviewOptions: { enableScripts: true, localResourceRoots: [] },
-            panelOptions:   { retainContextWhenHidden: true },
-        }),
-    ];
+    return [vscode.window.registerCustomEditorProvider(
+        'wurst.wpmPreview',
+        new WpmEditorProvider(),
+        { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
+    )];
 }

--- a/src/languageServer.ts
+++ b/src/languageServer.ts
@@ -59,7 +59,8 @@ export async function startLanguageClient(context: ExtensionContext): Promise<vo
     let installedVersion = 'detecting...';
     let availableUpdate: UpdateAvailable | undefined;
     const updateStatusBar = () => {
-        sb.text = availableUpdate ? '$(cloud-download) WurstScript Update' : '$(check) WurstScript';
+        sb.text = availableUpdate ? '$(circle-filled) WurstScript Update' : '$(check) WurstScript';
+        sb.color = availableUpdate ? '#3794ff' : undefined;
         sb.tooltip = [
             availableUpdate ? 'A newer WurstScript version is available.' : 'WurstScript language server is running.',
             `Version: ${installedVersion}`,

--- a/src/webview/objModEditor/assetBrowser.ts
+++ b/src/webview/objModEditor/assetBrowser.ts
@@ -1,4 +1,4 @@
-import { assetSearchScore } from '../../features/preview/fuzzy';
+import { assetSearchScore, fuzzyMatch } from '../../features/preview/fuzzy';
 import { esc } from '../objModWebviewUtils';
 import { effect, signal } from '../signals';
 import { detailCache, details, ui, vscodeApi, iconLoader, assetBrowserUi } from './state';
@@ -123,7 +123,7 @@ export function renderAssetGrid() {
     const o = opts[index];
     if (sourceFilter === 'import' && o.source !== 'import') continue;
     if (sourceFilter === 'wc3' && o.source === 'import') continue;
-    const score = assetSearchScore(query, o.label, o.value, o.detail || '');
+    const score = assetSearchScore(query, o.label, o.value, o.detail || '', fuzzyMatch);
     if (!Number.isFinite(score)) continue;
     ranked.push({ option: o, score, index });
   }

--- a/src/webview/objModEditor/state.ts
+++ b/src/webview/objModEditor/state.ts
@@ -51,11 +51,10 @@ export const search = document.getElementById('search') as HTMLInputElement;
 
 // A cross-file rawcode jump (see locateObjectAcrossSiblings in objModPreview.ts) always wins over a
 // restored selection — the user just asked to look at a specific object, so honor that over whatever
-// was open last time. Otherwise prefer the restored key, falling back to it only if that object still
-// exists in this file (it may have been deleted by an edit made elsewhere since).
-const restoredSelectedKey = typeof persisted.selectedKey === 'string' && objects.some(obj => obj.key === persisted.selectedKey)
-  ? persisted.selectedKey
-  : '';
+// was open last time. Otherwise resolve the stable rawcode identity to this parse's transient array
+// key, falling back only if that object was deleted by an edit made elsewhere.
+const restoredSelectedIdentity = typeof persisted.selectedIdentity === 'string' ? persisted.selectedIdentity : '';
+const restoredSelectedKey = objects.find(obj => obj.identity === restoredSelectedIdentity)?.key || '';
 const initialSelectedKey = initial.isPendingJump ? initial.selectedKey : (restoredSelectedKey || initial.selectedKey || '');
 
 // Cross-cutting state that's reassigned (not just mutated) from more than one module. Real ES module
@@ -139,12 +138,14 @@ export const assetBrowserUi = {
 // free. Merges onto whatever's already persisted (e.g. the splitter width in objModEditorWebview.ts)
 // rather than replacing it outright.
 effect(() => {
+  const selectedIdentity = objects.find(obj => obj.key === ui.selectedKey)?.identity || '';
   const collapsed = Array.from(collapsedNodes);
   const hiddenCategories = Array.from(ui.hiddenCategories);
   collapsedNodes.version; // tracked: re-persist when a tree branch is collapsed/expanded
   ui.hiddenCategories.version; // tracked: re-persist when the category filter changes
   vscodeApi.setState(Object.assign({}, vscodeApi.getState() || {}, {
     selectedKey: ui.selectedKey,
+    selectedIdentity,
     query: ui.query,
     fieldQuery: ui.fieldQuery,
     showTechnical: ui.showTechnical,
@@ -157,3 +158,10 @@ effect(() => {
     hiddenCategories: hiddenCategories,
   }));
 }, 'state.persistUi');
+
+// The host stores only this stable identity, keyed by the document's workspace-relative path. That
+// survives closing/reopening the editor and still resolves after Git reorders object arrays.
+effect(() => {
+  const identity = objects.find(obj => obj.key === ui.selectedKey)?.identity;
+  if (identity) vscodeApi.postMessage({ type: 'selectionChanged', identity });
+}, 'state.rememberSelection');

--- a/src/webview/objModEditor/types.ts
+++ b/src/webview/objModEditor/types.ts
@@ -1,5 +1,6 @@
 export interface ObjModObject {
   key: string;
+  identity: string;
   baseId: string;
   newId?: string;
   displayName: string;

--- a/src/webview/objModEditorWebview.ts
+++ b/src/webview/objModEditorWebview.ts
@@ -201,6 +201,12 @@ document.addEventListener('keydown', e => {
 const editableBadge = document.getElementById('editable-badge');
 if (editableBadge) editableBadge.addEventListener('click', saveNow);
 
+const refreshEditor = document.getElementById('refresh-editor');
+if (refreshEditor) refreshEditor.addEventListener('click', () => {
+  commitActiveEditor();
+  vscodeApi.postMessage({ type: 'refresh' });
+});
+
 // Density is a document-wide spacing scale (tree, header, field table all retune at once), so it's a
 // single class on <body> driving the :root / body.density-cozy variable pair in objModPreview.ts —
 // nothing has to re-render. The effect runs immediately on creation, which is what applies a restored


### PR DESCRIPTION
## Summary

- Release the editable WC3 pathing-map preview as `v0.12.15`.
- Preserve object-editor selection across file rewrites and add explicit refresh/recovery handling.
- Improve asset-browser fuzzy matching and add code-launched E2E coverage.
- Make available WurstScript updates visible with a blue filled-dot status-bar indicator.

## Validation

- `npm test`
- `npx tsc -p . --noEmit`
- `npm run lint` (passes with the existing unused `CopyFilePlugin` warning in `webpack.config.js`)
- `npm run publish` / VSIX contents verification
