### PR TITLE
Add editable map metadata editors

### DIFF
--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -14,7 +14,7 @@ const { test: base, expect } = require('@playwright/test');
 
 const { startHarnessServer } = require('./harness/server');
 const { createObjModHost } = require('./harness/objmodHost');
-const { createW3iHost, createWpmHost } = require('./harness/mapEditorHosts');
+const { createW3iHost, createWpmHost, createMmpHost, createW3cHost, createW3rHost } = require('./harness/mapEditorHosts');
 const { root } = require('./harness/tsLoader');
 
 /** Mirrors the webview API surface the shipped code uses. State lives in sessionStorage so it
@@ -121,6 +121,42 @@ const test = base.extend({
         const opened = [];
         await use(async (options = {}) => {
             const host = await createWpmHost({ origin: server.origin, ...options });
+            opened.push(host);
+            const wiring = await attachPageToHost(page, server, host);
+            return { host, page, ...wiring };
+        });
+        for (const host of opened) host.dispose();
+    },
+
+    /** Opens the editable .mmp minimap-icon editor. */
+    openMmp: async ({ page, server }, use) => {
+        const opened = [];
+        await use(async (options = {}) => {
+            const host = await createMmpHost({ origin: server.origin, ...options });
+            opened.push(host);
+            const wiring = await attachPageToHost(page, server, host);
+            return { host, page, ...wiring };
+        });
+        for (const host of opened) host.dispose();
+    },
+
+    /** Opens the editable .w3c camera editor. */
+    openW3c: async ({ page, server }, use) => {
+        const opened = [];
+        await use(async (options = {}) => {
+            const host = await createW3cHost({ origin: server.origin, ...options });
+            opened.push(host);
+            const wiring = await attachPageToHost(page, server, host);
+            return { host, page, ...wiring };
+        });
+        for (const host of opened) host.dispose();
+    },
+
+    /** Opens the editable .w3r region editor. */
+    openW3r: async ({ page, server }, use) => {
+        const opened = [];
+        await use(async (options = {}) => {
+            const host = await createW3rHost({ origin: server.origin, ...options });
             opened.push(host);
             const wiring = await attachPageToHost(page, server, host);
             return { host, page, ...wiring };

--- a/e2e/harness/makeFixtures.js
+++ b/e2e/harness/makeFixtures.js
@@ -106,14 +106,57 @@ function buildWpm() {
     return serializeWpm({ version: 0, width, height, data, tail: Buffer.alloc(0) });
 }
 
-/** Writes a fresh temp dir containing war3map.w3i / .wts / .wpm and returns its path. */
+function buildMmp() {
+    const w = new BinWriter(8 + 4 * 16);
+    w.writeI32(0); // version
+    w.writeI32(4); // icon count
+    const icon = (type, x, y, blue, green, red, alpha = 0xff) => {
+        w.writeI32(type); w.writeI32(x); w.writeI32(y);
+        w.writeU8(blue); w.writeU8(green); w.writeU8(red); w.writeU8(alpha);
+    };
+    icon(0, -1024, 512, 0xff, 0xff, 0xff); // default gold mine color
+    icon(1, 256, -768, 0x40, 0x80, 0xc0);
+    icon(2, 1024, 2048, 0xff, 0xff, 0xff, 0x80);
+    icon(77, 0, 0, 0x10, 0x20, 0x30);
+    return w.toBuffer();
+}
+
+function buildW3c() {
+    const w = new BinWriter(256);
+    w.writeI32(0); w.writeI32(2);
+    const camera = (name, values) => {
+        for (const value of values) w.writeF32(value);
+        w.writeString(name);
+    };
+    camera('Overview', [128, 256, 32, 90, 304, 1650, 0, 70, 5000, 0]);
+    camera('Boss Arena', [-512, 1024, 64, 180, 280, 2200, 3, 75, 6000, 1]);
+    return w.toBuffer();
+}
+
+function buildW3r() {
+    const w = new BinWriter(256);
+    w.writeI32(5); w.writeI32(2);
+    const region = (name, minX, maxX, minY, maxY, index, weather, sound, blue, green, red, endToken = 0) => {
+        w.writeF32(minX); w.writeF32(maxX); w.writeF32(minY); w.writeF32(maxY);
+        w.writeString(name); w.writeI32(index); w.writeId(weather); w.writeString(sound);
+        w.writeU8(blue); w.writeU8(green); w.writeU8(red); w.writeU8(endToken);
+    };
+    region('Spawn Area', -128, 256, -64, 384, 3, 'NULL', 'Sound\\Environment\\GrasslandDay', 0x40, 0x80, 0xc0);
+    region('Boss Room', 512, 1024, 768, 1280, 7, 'SNOW', '', 0x10, 0x20, 0x30, 1);
+    return w.toBuffer();
+}
+
+/** Writes a fresh temp dir containing the editable map-data fixtures and returns its path. */
 function makeMapFixtureDir() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wurst-e2e-map-'));
     fs.writeFileSync(path.join(dir, 'war3map.w3i'), buildW3i());
     fs.writeFileSync(path.join(dir, 'war3map.wts'), WTS, 'utf8');
     fs.writeFileSync(path.join(dir, 'war3map.wpm'), buildWpm());
+    fs.writeFileSync(path.join(dir, 'war3map.mmp'), buildMmp());
+    fs.writeFileSync(path.join(dir, 'war3map.w3c'), buildW3c());
+    fs.writeFileSync(path.join(dir, 'war3map.w3r'), buildW3r());
     fs.writeFileSync(path.join(dir, 'wurst.build'), 'projectName = wurst-e2e\n');
     return dir;
 }
 
-module.exports = { makeMapFixtureDir, buildW3i, buildWpm, WTS, W3I_VERSION };
+module.exports = { makeMapFixtureDir, buildW3i, buildWpm, buildMmp, buildW3c, buildW3r, WTS, W3I_VERSION };

--- a/e2e/harness/makeFixtures.js
+++ b/e2e/harness/makeFixtures.js
@@ -93,6 +93,21 @@ STRING 2
 E2E map description spanning
 two lines.
 }
+
+STRING 3
+{
+Resolved Overview
+}
+
+STRING 4
+{
+Resolved Spawn
+}
+
+STRING 5
+{
+Resolved Region Sound
+}
 `;
 
 /** 16x16 pathing map with a recognisable block of blocked cells to assert paint/erase against. */
@@ -128,7 +143,7 @@ function buildW3c() {
         for (const value of values) w.writeF32(value);
         w.writeString(name);
     };
-    camera('Overview', [128, 256, 32, 90, 304, 1650, 0, 70, 5000, 0]);
+    camera('TRIGSTR_003', [128, 256, 32, 90, 304, 1650, 0, 70, 5000, 0]);
     camera('Boss Arena', [-512, 1024, 64, 180, 280, 2200, 3, 75, 6000, 1]);
     return w.toBuffer();
 }
@@ -141,7 +156,7 @@ function buildW3r() {
         w.writeString(name); w.writeI32(index); w.writeId(weather); w.writeString(sound);
         w.writeU8(blue); w.writeU8(green); w.writeU8(red); w.writeU8(endToken);
     };
-    region('Spawn Area', -128, 256, -64, 384, 3, 'NULL', 'Sound\\Environment\\GrasslandDay', 0x40, 0x80, 0xc0);
+    region('TRIGSTR_004', -128, 256, -64, 384, 3, 'NULL', 'TRIGSTR_005', 0x40, 0x80, 0xc0);
     region('Boss Room', 512, 1024, 768, 1280, 7, 'SNOW', '', 0x10, 0x20, 0x30, 1);
     return w.toBuffer();
 }

--- a/e2e/harness/mapEditorHosts.js
+++ b/e2e/harness/mapEditorHosts.js
@@ -1,9 +1,8 @@
 'use strict';
 
 /**
- * Harnesses for the two editable map-data formats whose webview JS ships as an inline `<script>`
- * inside the host TypeScript: `.w3i` (W3iEditorProvider in mapDataPreview.ts) and `.wpm`
- * (WpmEditorProvider in wpmPreview.ts).
+ * Harnesses for the editable map-data formats whose webview JS ships as an inline `<script>`
+ * inside the host TypeScript: `.w3i`, `.mmp`, `.w3c`, `.w3r`, and `.wpm`.
  *
  * Until now that inline script was only checked by parsing it with `vm.Script` and grepping the
  * surrounding source for expected substrings — neither of which can tell whether the thing actually
@@ -19,6 +18,9 @@ const { makeMapFixtureDir } = require('./makeFixtures');
 
 const W3I_INTERNALS = `export const __e2e = { W3iEditorProvider, W3iDocument, renderW3iEditor };`;
 const WPM_INTERNALS = `export const __e2e = { WpmEditorProvider, WpmDocument, buildWpmHtml };`;
+const MMP_INTERNALS = `export const __e2e = { MmpEditorProvider, MmpDocument, renderMmpEditor, parseMmpFile };`;
+const W3C_INTERNALS = `export const __e2e = { W3cEditorProvider, W3cDocument, renderW3cEditor, parseW3cFile };`;
+const W3R_INTERNALS = `export const __e2e = { W3rEditorProvider, W3rDocument, renderW3rEditor, parseW3rFile };`;
 
 async function createEditorHost(opts, sourceFile, internals, fileName, providerFactory, isDirty) {
     const fixtureDir = opts.fixtureDir || makeMapFixtureDir();
@@ -79,4 +81,28 @@ function createWpmHost(opts) {
     );
 }
 
-module.exports = { createW3iHost, createWpmHost };
+function createMmpHost(opts) {
+    return createEditorHost(
+        opts, 'src/features/mapDataPreview.ts', MMP_INTERNALS, 'war3map.mmp',
+        (e2e) => new e2e.MmpEditorProvider(),
+        (doc) => doc.currentRevision !== doc.savedRevision,
+    );
+}
+
+function createW3cHost(opts) {
+    return createEditorHost(
+        opts, 'src/features/mapDataPreview.ts', W3C_INTERNALS, 'war3map.w3c',
+        (e2e) => new e2e.W3cEditorProvider(),
+        (doc) => doc.currentRevision !== doc.savedRevision,
+    );
+}
+
+function createW3rHost(opts) {
+    return createEditorHost(
+        opts, 'src/features/mapDataPreview.ts', W3R_INTERNALS, 'war3map.w3r',
+        (e2e) => new e2e.W3rEditorProvider(),
+        (doc) => doc.currentRevision !== doc.savedRevision,
+    );
+}
+
+module.exports = { createW3iHost, createWpmHost, createMmpHost, createW3cHost, createW3rHost };

--- a/e2e/harness/vscodeLauncher.js
+++ b/e2e/harness/vscodeLauncher.js
@@ -157,6 +157,9 @@ const EDITOR_ASSOCIATIONS = {
     '*.w3q': 'wurst.objModPreview',
     '*.w3i': 'wurst.w3iEditor',
     '*.wpm': 'wurst.wpmPreview',
+    '*.mmp': 'wurst.mmpEditor',
+    '*.w3c': 'wurst.w3cEditor',
+    '*.w3r': 'wurst.w3rEditor',
 };
 
 function writeUserSettings(userDataDir, settings) {

--- a/e2e/specs/mmp-editor.spec.js
+++ b/e2e/specs/mmp-editor.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/** The editable .mmp minimap/lobby-preview icon list. */
+
+const { test, expect } = require('../fixtures');
+
+test('renders icon types, coordinates, colors, and the default-color state', async ({ openMmp }) => {
+    const { page, host, pageErrors } = await openMmp();
+
+    await expect(page.locator('#mmpCount')).toHaveText('4');
+    await expect(page.locator('[data-row="0"] [data-field="type"]')).toHaveValue('0');
+    await expect(page.locator('[data-row="0"] [data-field="x"]')).toHaveValue('-1024');
+    await expect(page.locator('[data-row="0"] [data-default-color]')).toBeChecked();
+    await expect(page.locator('[data-row="0"] [data-field="color"]')).toBeDisabled();
+    await expect(page.locator('.mmp-footer-hint')).toContainText('no custom tint');
+    await expect(page.locator('[data-row="1"] .type-label')).toHaveText('Neutral Building / House');
+    await expect(page.locator('[data-row="3"] .type-label')).toHaveText('Unknown / custom (77)');
+    await expect(page.locator('[data-row="3"] [data-field="type"]')).toHaveValue('77');
+    expect(host.doc.file.icons[1].red).toBe(0xc0);
+    expect(pageErrors).toEqual([]);
+});
+
+test('removing an icon is undoable and redoable', async ({ openMmp }) => {
+    const { page, host } = await openMmp();
+
+    await page.click('[data-row="1"] [data-remove]');
+    await expect.poll(() => host.doc.file.icons.length).toBe(3);
+    await expect(page.locator('#mmpCount')).toHaveText('3');
+    expect(host.editLabels).toEqual(['Remove minimap icon']);
+    expect(host.isDirty).toBe(true);
+
+    host.undo();
+    await expect.poll(() => host.doc.file.icons.length).toBe(4);
+    await expect(page.locator('#mmpCount')).toHaveText('4');
+    expect(host.isDirty).toBe(false);
+
+    host.redo();
+    await expect.poll(() => host.doc.file.icons.length).toBe(3);
+    await expect(page.locator('#mmpCount')).toHaveText('3');
+});
+
+test('editing coordinates, type, and color fields updates the icon', async ({ openMmp }) => {
+    const { page, host } = await openMmp();
+
+    await page.selectOption('[data-row="0"] [data-field="type"]', '2');
+    await page.fill('[data-row="0"] [data-field="x"]', '1234');
+    await page.locator('[data-row="0"] [data-field="x"]').blur();
+    await page.uncheck('[data-row="0"] [data-default-color]');
+    await page.fill('[data-row="0"] [data-field="color"]', '#123456');
+    await page.locator('[data-row="0"] [data-field="color"]').blur();
+    await page.fill('[data-row="0"] [data-field="alpha"]', '96');
+    await page.locator('[data-row="0"] [data-field="alpha"]').blur();
+
+    await expect.poll(() => host.doc.file.icons[0].type).toBe(2);
+    expect(host.doc.file.icons[0]).toMatchObject({ x: 1234, red: 0x12, green: 0x34, blue: 0x56, alpha: 96 });
+    await expect(page.locator('[data-row="0"] .type-label')).toHaveText('Player Start');
+    expect(host.editLabels).toEqual(['Edit icon type', 'Edit icon x', 'Edit icon color', 'Edit icon alpha']);
+});
+
+test('adding an icon and saving round-trips the edited list', async ({ openMmp }) => {
+    const { page, host } = await openMmp();
+
+    await page.click('[data-add]');
+    await expect.poll(() => host.doc.file.icons.length).toBe(5);
+    await page.selectOption('[data-row="4"] [data-field="type"]', '2');
+    await page.locator('[data-row="4"] [data-field="type"]').blur();
+    await page.fill('[data-row="4"] [data-field="x"]', '900');
+    await page.locator('[data-row="4"] [data-field="x"]').blur();
+    await page.fill('[data-row="4"] [data-field="y"]', '-450');
+    await page.locator('[data-row="4"] [data-field="y"]').blur();
+    await page.uncheck('[data-row="4"] [data-default-color]');
+    await page.fill('[data-row="4"] [data-field="color"]', '#abcdef');
+    await page.locator('[data-row="4"] [data-field="color"]').blur();
+
+    await host.save();
+    expect(host.isDirty).toBe(false);
+    const reparsed = host.internals.parseMmpFile(host.readFile());
+    expect(reparsed.error).toBeUndefined();
+    expect(reparsed.icons).toHaveLength(5);
+    expect(reparsed.icons[4]).toMatchObject({ type: 2, x: 900, y: -450, red: 0xab, green: 0xcd, blue: 0xef, alpha: 0xff });
+});

--- a/e2e/specs/w3c-w3r-editors.spec.js
+++ b/e2e/specs/w3c-w3r-editors.spec.js
@@ -47,6 +47,7 @@ test('camera editor accepts fractional float32 values', async ({ openW3c }) => {
 
     await page.fill('[data-row="0"] [data-field="targetX"]', '0.1');
     await page.locator('[data-row="0"] [data-field="targetX"]').blur();
+    await expect(page.locator('[data-row="0"] [data-field="targetX"]')).toHaveValue(Math.fround(0.1).toString());
     await host.save();
 
     const reparsed = host.internals.parseW3cFile(host.readFile());
@@ -95,6 +96,7 @@ test('region editor accepts fractional float32 bounds', async ({ openW3r }) => {
 
     await page.fill('[data-row="0"] [data-field="minX"]', '12.345');
     await page.locator('[data-row="0"] [data-field="minX"]').blur();
+    await expect(page.locator('[data-row="0"] [data-field="minX"]')).toHaveValue(Math.fround(12.345).toString());
     await host.save();
 
     const reparsed = host.internals.parseW3rFile(host.readFile());

--- a/e2e/specs/w3c-w3r-editors.spec.js
+++ b/e2e/specs/w3c-w3r-editors.spec.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { test, expect } = require('../fixtures');
+
+test('camera editor exposes named fields and supports edit, undo, and save', async ({ openW3c }) => {
+    const { page, host, pageErrors } = await openW3c();
+
+    await expect(page.locator('#editorCount')).toHaveText('2');
+    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Overview');
+    await expect(page.locator('[data-row="0"] [data-field="targetX"]')).toHaveValue('128');
+    await expect(page.locator('[data-row="1"] [data-field="name"]')).toHaveValue('Boss Arena');
+    expect(pageErrors).toEqual([]);
+
+    await page.fill('[data-row="0"] [data-field="name"]', 'Edited Overview');
+    await page.locator('[data-row="0"] [data-field="name"]').blur();
+    await page.fill('[data-row="0"] [data-field="distance"]', '1900');
+    await page.locator('[data-row="0"] [data-field="distance"]').blur();
+    await expect.poll(() => host.doc.file.cameras[0].distance).toBe(1900);
+    expect(host.isDirty).toBe(true);
+
+    host.undo();
+    expect(host.doc.file.cameras[0].distance).toBe(1650);
+    host.undo();
+    expect(host.doc.file.cameras[0].name).toBe('Overview');
+    expect(host.isDirty).toBe(false);
+
+    host.redo();
+    host.redo();
+    await host.save();
+    const reparsed = host.internals.parseW3cFile(host.readFile());
+    expect(reparsed.cameras[0]).toMatchObject({ name: 'Edited Overview', distance: 1900 });
+});
+
+test('camera editor can add and remove camera records', async ({ openW3c }) => {
+    const { page, host } = await openW3c();
+
+    await page.click('[data-add]');
+    await expect.poll(() => host.doc.file.cameras.length).toBe(3);
+    await expect(page.locator('[data-row="2"] [data-field="name"]')).toHaveValue('New Camera');
+    await page.click('[data-row="2"] [data-remove]');
+    await expect.poll(() => host.doc.file.cameras.length).toBe(2);
+    expect(host.editLabels).toEqual(['Add camera', 'Remove camera']);
+});
+
+test('region editor exposes bounds, environment, color, and round-trips edits', async ({ openW3r }) => {
+    const { page, host, pageErrors } = await openW3r();
+
+    await expect(page.locator('#editorCount')).toHaveText('2');
+    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Spawn Area');
+    await expect(page.locator('[data-row="0"] [data-field="minX"]')).toHaveValue('-128');
+    await expect(page.locator('[data-row="0"] [data-field="weatherId"]')).toHaveValue('NULL');
+    await expect(page.locator('[data-row="0"] [data-field="color"]')).toHaveValue('#c08040');
+    expect(pageErrors).toEqual([]);
+
+    await page.fill('[data-row="0"] [data-field="name"]', 'Edited Area');
+    await page.locator('[data-row="0"] [data-field="name"]').blur();
+    await page.fill('[data-row="0"] [data-field="maxY"]', '512');
+    await page.locator('[data-row="0"] [data-field="maxY"]').blur();
+    await page.fill('[data-row="0"] [data-field="weatherId"]', 'RAIN');
+    await page.locator('[data-row="0"] [data-field="weatherId"]').blur();
+    await page.fill('[data-row="0"] [data-field="color"]', '#abcdef');
+    await page.locator('[data-row="0"] [data-field="color"]').blur();
+    await expect.poll(() => host.doc.file.regions[0].maxY).toBe(512);
+    expect(host.doc.file.regions[0]).toMatchObject({ name: 'Edited Area', weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+
+    await host.save();
+    const reparsed = host.internals.parseW3rFile(host.readFile());
+    expect(reparsed.regions[0]).toMatchObject({ name: 'Edited Area', maxY: 512, weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+});
+
+test('region editor can add and remove region records', async ({ openW3r }) => {
+    const { page, host } = await openW3r();
+
+    await page.click('[data-add]');
+    await expect.poll(() => host.doc.file.regions.length).toBe(3);
+    await expect(page.locator('[data-row="2"] [data-field="name"]')).toHaveValue('New Region');
+    await page.click('[data-row="2"] [data-remove]');
+    await expect.poll(() => host.doc.file.regions.length).toBe(2);
+    expect(host.editLabels).toEqual(['Add region', 'Remove region']);
+});

--- a/e2e/specs/w3c-w3r-editors.spec.js
+++ b/e2e/specs/w3c-w3r-editors.spec.js
@@ -6,7 +6,7 @@ test('camera editor exposes named fields and supports edit, undo, and save', asy
     const { page, host, pageErrors } = await openW3c();
 
     await expect(page.locator('#editorCount')).toHaveText('2');
-    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Overview');
+    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Resolved Overview');
     await expect(page.locator('[data-row="0"] [data-field="targetX"]')).toHaveValue('128');
     await expect(page.locator('[data-row="1"] [data-field="name"]')).toHaveValue('Boss Arena');
     expect(pageErrors).toEqual([]);
@@ -21,14 +21,15 @@ test('camera editor exposes named fields and supports edit, undo, and save', asy
     host.undo();
     expect(host.doc.file.cameras[0].distance).toBe(1650);
     host.undo();
-    expect(host.doc.file.cameras[0].name).toBe('Overview');
+    expect(host.doc.wtsEdits.has(3)).toBe(false);
     expect(host.isDirty).toBe(false);
 
     host.redo();
     host.redo();
     await host.save();
     const reparsed = host.internals.parseW3cFile(host.readFile());
-    expect(reparsed.cameras[0]).toMatchObject({ name: 'Edited Overview', distance: 1900 });
+    expect(reparsed.cameras[0]).toMatchObject({ name: 'TRIGSTR_003', distance: 1900 });
+    expect(host.readText('war3map.wts')).toContain('Edited Overview');
 });
 
 test('camera editor can add and remove camera records', async ({ openW3c }) => {
@@ -45,6 +46,9 @@ test('camera editor can add and remove camera records', async ({ openW3c }) => {
 test('camera editor accepts fractional float32 values', async ({ openW3c }) => {
     const { page, host } = await openW3c();
 
+    await page.fill('[data-row="0"] [data-field="targetX"]', '1e39');
+    await page.locator('[data-row="0"] [data-field="targetX"]').blur();
+    expect(host.doc.file.cameras[0].targetX).toBe(128);
     await page.fill('[data-row="0"] [data-field="targetX"]', '0.1');
     await page.locator('[data-row="0"] [data-field="targetX"]').blur();
     await expect(page.locator('[data-row="0"] [data-field="targetX"]')).toHaveValue(Math.fround(0.1).toString());
@@ -58,7 +62,7 @@ test('region editor exposes bounds, environment, color, and round-trips edits', 
     const { page, host, pageErrors } = await openW3r();
 
     await expect(page.locator('#editorCount')).toHaveText('2');
-    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Spawn Area');
+    await expect(page.locator('[data-row="0"] [data-field="name"]')).toHaveValue('Resolved Spawn');
     await expect(page.locator('[data-row="0"] [data-field="minX"]')).toHaveValue('-128');
     await expect(page.locator('[data-row="0"] [data-field="weatherId"]')).toHaveValue('NULL');
     await expect(page.locator('[data-row="0"] [data-field="color"]')).toHaveValue('#c08040');
@@ -73,11 +77,13 @@ test('region editor exposes bounds, environment, color, and round-trips edits', 
     await page.fill('[data-row="0"] [data-field="color"]', '#abcdef');
     await page.locator('[data-row="0"] [data-field="color"]').blur();
     await expect.poll(() => host.doc.file.regions[0].maxY).toBe(512);
-    expect(host.doc.file.regions[0]).toMatchObject({ name: 'Edited Area', weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+    expect(host.doc.file.regions[0]).toMatchObject({ name: 'TRIGSTR_004', weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+    expect(host.doc.wtsEdits.get(4)).toBe('Edited Area');
 
     await host.save();
     const reparsed = host.internals.parseW3rFile(host.readFile());
-    expect(reparsed.regions[0]).toMatchObject({ name: 'Edited Area', maxY: 512, weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+    expect(reparsed.regions[0]).toMatchObject({ name: 'TRIGSTR_004', maxY: 512, weatherId: 'RAIN', red: 0xab, green: 0xcd, blue: 0xef });
+    expect(host.readText('war3map.wts')).toContain('Edited Area');
 });
 
 test('region editor can add and remove region records', async ({ openW3r }) => {
@@ -94,6 +100,9 @@ test('region editor can add and remove region records', async ({ openW3r }) => {
 test('region editor accepts fractional float32 bounds', async ({ openW3r }) => {
     const { page, host } = await openW3r();
 
+    await page.fill('[data-row="0"] [data-field="minX"]', '1e39');
+    await page.locator('[data-row="0"] [data-field="minX"]').blur();
+    expect(host.doc.file.regions[0].minX).toBe(-128);
     await page.fill('[data-row="0"] [data-field="minX"]', '12.345');
     await page.locator('[data-row="0"] [data-field="minX"]').blur();
     await expect(page.locator('[data-row="0"] [data-field="minX"]')).toHaveValue(Math.fround(12.345).toString());

--- a/e2e/specs/w3c-w3r-editors.spec.js
+++ b/e2e/specs/w3c-w3r-editors.spec.js
@@ -42,6 +42,17 @@ test('camera editor can add and remove camera records', async ({ openW3c }) => {
     expect(host.editLabels).toEqual(['Add camera', 'Remove camera']);
 });
 
+test('camera editor accepts fractional float32 values', async ({ openW3c }) => {
+    const { page, host } = await openW3c();
+
+    await page.fill('[data-row="0"] [data-field="targetX"]', '0.1');
+    await page.locator('[data-row="0"] [data-field="targetX"]').blur();
+    await host.save();
+
+    const reparsed = host.internals.parseW3cFile(host.readFile());
+    expect(reparsed.cameras[0].targetX).toBe(Math.fround(0.1));
+});
+
 test('region editor exposes bounds, environment, color, and round-trips edits', async ({ openW3r }) => {
     const { page, host, pageErrors } = await openW3r();
 
@@ -77,4 +88,15 @@ test('region editor can add and remove region records', async ({ openW3r }) => {
     await page.click('[data-row="2"] [data-remove]');
     await expect.poll(() => host.doc.file.regions.length).toBe(2);
     expect(host.editLabels).toEqual(['Add region', 'Remove region']);
+});
+
+test('region editor accepts fractional float32 bounds', async ({ openW3r }) => {
+    const { page, host } = await openW3r();
+
+    await page.fill('[data-row="0"] [data-field="minX"]', '12.345');
+    await page.locator('[data-row="0"] [data-field="minX"]').blur();
+    await host.save();
+
+    const reparsed = host.internals.parseW3rFile(host.readFile());
+    expect(reparsed.regions[0].minX).toBe(Math.fround(12.345));
 });

--- a/package.json
+++ b/package.json
@@ -529,6 +529,31 @@
                 "priority": "default"
             },
             {
+                "viewType": "wurst.mapDataArchivePreview",
+                "displayName": "WC3 Map Data (read-only)",
+                "selector": [
+                    {
+                        "filenamePattern": "*.mmp"
+                    },
+                    {
+                        "filenamePattern": "*.MMP"
+                    },
+                    {
+                        "filenamePattern": "*.w3c"
+                    },
+                    {
+                        "filenamePattern": "*.W3C"
+                    },
+                    {
+                        "filenamePattern": "*.w3r"
+                    },
+                    {
+                        "filenamePattern": "*.W3R"
+                    }
+                ],
+                "priority": "option"
+            },
+            {
                 "viewType": "wurst.w3cEditor",
                 "displayName": "WC3 Cameras (editable)",
                 "selector": [

--- a/package.json
+++ b/package.json
@@ -529,32 +529,53 @@
                 "priority": "default"
             },
             {
-                "viewType": "wurst.mapDataPreview",
-                "displayName": "WC3 Map Data",
+                "viewType": "wurst.w3cEditor",
+                "displayName": "WC3 Cameras (editable)",
+                "selector": [
+                    {
+                        "filenamePattern": "*.w3c"
+                    },
+                    {
+                        "filenamePattern": "*.W3C"
+                    }
+                ],
+                "priority": "default"
+            },
+            {
+                "viewType": "wurst.w3rEditor",
+                "displayName": "WC3 Regions (editable)",
+                "selector": [
+                    {
+                        "filenamePattern": "*.w3r"
+                    },
+                    {
+                        "filenamePattern": "*.W3R"
+                    }
+                ],
+                "priority": "default"
+            },
+            {
+                "viewType": "wurst.mmpEditor",
+                "displayName": "WC3 Minimap Icons (editable)",
                 "selector": [
                     {
                         "filenamePattern": "*.mmp"
                     },
                     {
                         "filenamePattern": "*.MMP"
-                    },
+                    }
+                ],
+                "priority": "default"
+            },
+            {
+                "viewType": "wurst.mapDataPreview",
+                "displayName": "WC3 Map Data",
+                "selector": [
                     {
                         "filenamePattern": "*.shd"
                     },
                     {
                         "filenamePattern": "*.SHD"
-                    },
-                    {
-                        "filenamePattern": "*.w3c"
-                    },
-                    {
-                        "filenamePattern": "*.W3C"
-                    },
-                    {
-                        "filenamePattern": "*.w3r"
-                    },
-                    {
-                        "filenamePattern": "*.W3R"
                     },
                     {
                         "filenamePattern": "*.w3e"

--- a/src/features/mapDataPreview.ts
+++ b/src/features/mapDataPreview.ts
@@ -1436,9 +1436,12 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
         return doc;
     }
     async resolveCustomEditor(doc: W3rDocument, panel: vscode.WebviewPanel): Promise<void> {
-        panel.webview.options = { enableScripts: true, localResourceRoots: [] }; doc.webview = panel.webview;
-        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
-        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc)); this.render(doc, panel.webview);
+        const webview = panel.webview;
+        webview.options = { enableScripts: true, localResourceRoots: [] };
+        doc.webview = webview;
+        panel.onDidDispose(() => { if (doc.webview === webview) doc.webview = undefined; });
+        webview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
+        this.render(doc, webview);
     }
     private render(doc: W3rDocument, webview: vscode.Webview): void {
         const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);
@@ -1461,10 +1464,19 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
     private removeRegion(doc: W3rDocument, index: number): void { const removed = { ...doc.file.regions[index] }; this.pushEdit(doc, 'Remove region', { apply: () => { doc.file.regions.splice(index, 1); }, revert: () => { doc.file.regions.splice(index, 0, removed); } }); }
     private editRegionField(doc: W3rDocument, index: number, field: string, rawValue: string): void {
         const before = { ...doc.file.regions[index] }; const after = { ...before };
-        if (field === 'name' || field === 'weatherId' || field === 'sound') after[field] = rawValue;
-        else if (field === 'color') { const color = parseMmpColor(rawValue); if (!color) return; Object.assign(after, color); }
-        else if (W3R_NUMERIC_FIELDS.has(field as keyof W3rRegion)) { const value = Number(rawValue); if (!Number.isFinite(value) || (field === 'index' && !Number.isInteger(value))) return; after[field as keyof W3rRegion] = value as never; }
-        else return;
+        if (field === 'name' || field === 'weatherId' || field === 'sound') {
+            after[field] = rawValue;
+        } else if (field === 'color') {
+            const color = parseMmpColor(rawValue);
+            if (!color) return;
+            Object.assign(after, color);
+        } else if (W3R_NUMERIC_FIELDS.has(field as keyof W3rRegion)) {
+            const value = Number(rawValue);
+            if (!Number.isFinite(value) || (field === 'index' && !Number.isInteger(value))) return;
+            after[field as keyof W3rRegion] = value as never;
+        } else {
+            return;
+        }
         if (JSON.stringify(before) === JSON.stringify(after)) return;
         this.pushEdit(doc, `Edit region ${field}`, { apply: () => { doc.file.regions[index] = { ...after }; }, revert: () => { doc.file.regions[index] = { ...before }; } });
     }
@@ -1643,11 +1655,12 @@ class MmpEditorProvider implements vscode.CustomEditorProvider<MmpDocument> {
     }
 
     async resolveCustomEditor(doc: MmpDocument, panel: vscode.WebviewPanel): Promise<void> {
-        panel.webview.options = { enableScripts: true, localResourceRoots: [] };
-        doc.webview = panel.webview;
-        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
-        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
-        this.render(doc, panel.webview);
+        const panelWebview = panel.webview;
+        panelWebview.options = { enableScripts: true, localResourceRoots: [] };
+        doc.webview = panelWebview;
+        panel.onDidDispose(() => { if (doc.webview === panelWebview) doc.webview = undefined; });
+        panelWebview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
+        this.render(doc, panelWebview);
     }
 
     private render(doc: MmpDocument, webview: vscode.Webview): void {

--- a/src/features/mapDataPreview.ts
+++ b/src/features/mapDataPreview.ts
@@ -1230,18 +1230,51 @@ const W3C_NUMERIC_FIELDS = new Set<keyof W3cCamera>([
     'targetX', 'targetY', 'zOffset', 'rotation', 'angleOfAttack', 'distance', 'roll', 'fieldOfView', 'farZ', 'unknown',
 ]);
 
-function w3cCameraInput(camera: W3cCamera, index: number, field: keyof W3cCamera, className = ''): string {
-    const value = field === 'name' ? camera.name : fmtF32(camera[field] as number);
-    const type = field === 'name' ? 'text' : 'number';
-    const step = field === 'name' ? '' : ' step="any"';
-    return `<input class="list-input ${className}" type="${type}"${step} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Camera ${index + 1} ${field}">`;
+function resolveEditableTriggerString(raw: string, triggerStrings: TriggerStringTable, wtsEdits: Map<number, string>): string {
+    const match = /^TRIGSTR_(\d+)$/i.exec(raw.trim());
+    if (!match) return raw;
+    const id = Number(match[1]);
+    if (wtsEdits.has(id)) return wtsEdits.get(id) as string;
+    const resolved = resolveTriggerString(raw, triggerStrings);
+    return resolved.missing ? raw : String(resolved.value ?? '');
 }
 
-function renderW3cList(file: W3cFile): string {
+function makeTriggerStringEdit(raw: string, triggerStrings: TriggerStringTable, wtsEdits: Map<number, string>, value: string): W3cEdit | undefined {
+    const match = /^TRIGSTR_(\d+)$/i.exec(raw.trim());
+    if (!match) return undefined;
+    const id = Number(match[1]);
+    const current = wtsEdits.get(id) ?? String(resolveTriggerString(raw, triggerStrings).value ?? '');
+    if (current === value) return undefined;
+    const had = wtsEdits.has(id);
+    const previous = wtsEdits.get(id);
+    return {
+        apply: () => { wtsEdits.set(id, value); },
+        revert: () => { if (had) wtsEdits.set(id, previous as string); else wtsEdits.delete(id); },
+    };
+}
+
+async function writeTriggerStringEdits(edits: Map<number, string>, wtsUri: vscode.Uri | undefined, wtsExists: boolean): Promise<void> {
+    if (!edits.size || !wtsUri) return;
+    let original = '';
+    if (wtsExists) {
+        try { original = Buffer.from(await vscode.workspace.fs.readFile(wtsUri)).toString('utf8'); } catch { /* create fresh */ }
+    }
+    await vscode.workspace.fs.writeFile(wtsUri, Buffer.from(applyWtsEdits(original, edits), 'utf8'));
+}
+
+function w3cCameraInput(camera: W3cCamera, index: number, field: keyof W3cCamera, className = '', triggerStrings: TriggerStringTable = new Map(), wtsEdits: Map<number, string> = new Map()): string {
+    const value = field === 'name' ? resolveEditableTriggerString(camera.name, triggerStrings, wtsEdits) : fmtF32(camera[field] as number);
+    const type = field === 'name' ? 'text' : 'number';
+    const step = field === 'name' ? '' : ' step="any"';
+    const source = field === 'name' && /^TRIGSTR_\d+$/i.test(camera.name.trim()) ? ` title="Source: ${escapeHtml(camera.name)}"` : '';
+    return `<input class="list-input ${className}" type="${type}"${step}${source} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Camera ${index + 1} ${field}">`;
+}
+
+function renderW3cList(file: W3cFile, triggerStrings: TriggerStringTable = new Map(), wtsEdits: Map<number, string> = new Map()): string {
     if (!file.cameras.length) return '<p class="empty">No cameras. Add one to create a camera record.</p>';
     const rows = file.cameras.map((camera, index) => `<tr data-row="${index}">
   <td class="num row-number">${index + 1}</td>
-  <td>${w3cCameraInput(camera, index, 'name')}</td>
+  <td>${w3cCameraInput(camera, index, 'name', '', triggerStrings, wtsEdits)}</td>
   <td>${w3cCameraInput(camera, index, 'targetX', 'mono')}</td>
   <td>${w3cCameraInput(camera, index, 'targetY', 'mono')}</td>
   <td>${w3cCameraInput(camera, index, 'zOffset', 'mono')}</td>
@@ -1258,7 +1291,7 @@ function renderW3cList(file: W3cFile): string {
 }
 
 function renderW3cEditor(doc: W3cDocument, fileName: string): string {
-    return renderEditableListPage(fileName, `WC3 cameras — v${doc.file.version}`, doc.file.cameras.length, 'cameras', renderW3cList(doc.file), 'Camera values are stored as floating-point Warcraft III camera parameters.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
+    return renderEditableListPage(fileName, `WC3 cameras — v${doc.file.version}`, doc.file.cameras.length, 'cameras', renderW3cList(doc.file, doc.wtsTable, doc.wtsEdits), 'Camera values are stored as floating-point Warcraft III camera parameters.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
 .w3c-table { min-width: 1500px; }
 .w3c-table th:nth-child(1) { width: 42px; }.w3c-table th:nth-child(2) { width: 180px; }.w3c-table th:nth-child(n+3):nth-child(-n+12) { width: 110px; }
 `);
@@ -1269,7 +1302,8 @@ class W3cDocument implements vscode.CustomDocument {
     savedRevision = 0;
     nextRevision = 1;
     webview?: vscode.Webview;
-    constructor(readonly uri: vscode.Uri, public file: W3cFile) {}
+    wtsEdits = new Map<number, string>();
+    constructor(readonly uri: vscode.Uri, public file: W3cFile, public wtsTable: TriggerStringTable, public wtsUri: vscode.Uri | undefined, public wtsExists: boolean) {}
     dispose(): void {}
 }
 
@@ -1281,7 +1315,8 @@ class W3cEditorProvider implements vscode.CustomEditorProvider<W3cDocument> {
 
     async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<W3cDocument> {
         const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
-        const doc = new W3cDocument(uri, parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        const { uri: wtsUri, exists } = findWtsUri(uri);
+        const doc = new W3cDocument(uri, parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(source))), loadTriggerStringsForUri(uri), wtsUri, exists);
         if (openContext.backupId) { doc.currentRevision = 1; doc.nextRevision = 2; }
         return doc;
     }
@@ -1329,10 +1364,14 @@ class W3cEditorProvider implements vscode.CustomEditorProvider<W3cDocument> {
     private editCameraField(doc: W3cDocument, index: number, field: string, rawValue: string): void {
         const before = { ...doc.file.cameras[index] };
         const after = { ...before };
-        if (field === 'name') after.name = rawValue;
+        if (field === 'name') {
+            const triggerEdit = makeTriggerStringEdit(before.name, doc.wtsTable, doc.wtsEdits, rawValue);
+            if (triggerEdit) return this.pushEdit(doc, `Edit camera ${field}`, triggerEdit);
+            after.name = rawValue;
+        }
         else if (W3C_NUMERIC_FIELDS.has(field as keyof W3cCamera)) {
             const value = Number(rawValue);
-            if (!Number.isFinite(value)) return;
+            if (!Number.isFinite(value) || !Number.isFinite(Math.fround(value))) return;
             after[field as keyof W3cCamera] = value as never;
         } else return;
         if (JSON.stringify(before) === JSON.stringify(after)) return;
@@ -1347,16 +1386,21 @@ class W3cEditorProvider implements vscode.CustomEditorProvider<W3cDocument> {
     }
 
     private postState(doc: W3cDocument): void {
-        void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3cList(doc.file), count: doc.file.cameras.length, isDirty: doc.currentRevision !== doc.savedRevision });
+        void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3cList(doc.file, doc.wtsTable, doc.wtsEdits), count: doc.file.cameras.length, isDirty: doc.currentRevision !== doc.savedRevision });
     }
 
     async saveCustomDocument(doc: W3cDocument): Promise<void> {
         await this.write(doc, doc.uri);
+        await writeTriggerStringEdits(doc.wtsEdits, doc.wtsUri, doc.wtsExists);
         doc.savedRevision = doc.currentRevision;
         this.postState(doc);
     }
 
-    async saveCustomDocumentAs(doc: W3cDocument, target: vscode.Uri): Promise<void> { await vscode.workspace.fs.writeFile(target, serializeValidatedW3c(doc.file, target.path)); }
+    async saveCustomDocumentAs(doc: W3cDocument, target: vscode.Uri): Promise<void> {
+        await vscode.workspace.fs.writeFile(target, serializeValidatedW3c(doc.file, target.path));
+        const { uri, exists } = findWtsUri(target);
+        await writeTriggerStringEdits(doc.wtsEdits, uri, exists);
+    }
 
     private async write(doc: W3cDocument, uri: vscode.Uri): Promise<void> {
         const bytes = serializeValidatedW3c(doc.file, uri.path);
@@ -1364,7 +1408,12 @@ class W3cEditorProvider implements vscode.CustomEditorProvider<W3cDocument> {
         await vscode.workspace.fs.writeFile(uri, bytes);
     }
 
-    async revertCustomDocument(doc: W3cDocument): Promise<void> { doc.file = parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri))); doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview); }
+    async revertCustomDocument(doc: W3cDocument): Promise<void> {
+        doc.file = parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri)));
+        doc.wtsTable = loadTriggerStringsForUri(doc.uri); doc.wtsEdits.clear();
+        const { uri, exists } = findWtsUri(doc.uri); doc.wtsUri = uri; doc.wtsExists = exists;
+        doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview);
+    }
 
     async backupCustomDocument(doc: W3cDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> {
         await vscode.workspace.fs.writeFile(context.destination, serializeValidatedW3c(doc.file, doc.uri.path));
@@ -1402,23 +1451,29 @@ function normalizeW3cCamera(camera: W3cCamera): W3cCamera {
 
 const W3R_NUMERIC_FIELDS = new Set<keyof W3rRegion>(['minX', 'maxX', 'minY', 'maxY', 'index']);
 
-function w3rRegionInput(region: W3rRegion, index: number, field: keyof W3rRegion, className = ''): string {
-    const value = field === 'name' || field === 'weatherId' || field === 'sound' ? region[field] as string : fmtF32(region[field] as number);
+function w3rRegionInput(region: W3rRegion, index: number, field: keyof W3rRegion, className = '', triggerStrings: TriggerStringTable = new Map(), wtsEdits: Map<number, string> = new Map()): string {
+    const isString = field === 'name' || field === 'weatherId' || field === 'sound';
+    let value: string;
+    if (isString && field !== 'weatherId') value = resolveEditableTriggerString(region[field] as string, triggerStrings, wtsEdits);
+    else if (isString) value = region[field] as string;
+    else value = fmtF32(region[field] as number);
     const type = field === 'name' || field === 'weatherId' || field === 'sound' ? 'text' : 'number';
     const step = type === 'number' && field !== 'index' ? ' step="any"' : '';
     const maxLength = field === 'weatherId' ? ' maxlength="4"' : '';
-    return `<input class="list-input ${className}" type="${type}"${step}${maxLength} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Region ${index + 1} ${field}">`;
+    const raw = field === 'name' || field === 'sound' ? region[field] as string : '';
+    const source = raw && /^TRIGSTR_\d+$/i.test(raw.trim()) ? ` title="Source: ${escapeHtml(raw)}"` : '';
+    return `<input class="list-input ${className}" type="${type}"${step}${maxLength}${source} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Region ${index + 1} ${field}">`;
 }
 
-function renderW3rList(file: W3rFile): string {
+function renderW3rList(file: W3rFile, triggerStrings: TriggerStringTable = new Map(), wtsEdits: Map<number, string> = new Map()): string {
     if (!file.regions.length) return '<p class="empty">No regions. Add one to create a region record.</p>';
     const rows = file.regions.map((region, index) => `<tr data-row="${index}">
   <td class="num row-number">${index + 1}</td>
-  <td>${w3rRegionInput(region, index, 'name')}</td>
+  <td>${w3rRegionInput(region, index, 'name', '', triggerStrings, wtsEdits)}</td>
   <td>${w3rRegionInput(region, index, 'minX', 'mono')}</td><td>${w3rRegionInput(region, index, 'maxX', 'mono')}</td>
   <td>${w3rRegionInput(region, index, 'minY', 'mono')}</td><td>${w3rRegionInput(region, index, 'maxY', 'mono')}</td>
   <td>${w3rRegionInput(region, index, 'index', 'mono')}</td>
-  <td>${w3rRegionInput(region, index, 'weatherId', 'mono')}</td><td>${w3rRegionInput(region, index, 'sound')}</td>
+  <td>${w3rRegionInput(region, index, 'weatherId', 'mono', triggerStrings, wtsEdits)}</td><td>${w3rRegionInput(region, index, 'sound', '', triggerStrings, wtsEdits)}</td>
   <td class="color-cell"><input class="list-color" type="color" data-index="${index}" data-field="color" value="${colorHex(region.red, region.green, region.blue)}" aria-label="Region ${index + 1} color"></td>
   <td><button type="button" class="remove-button" data-remove="${index}">Remove</button></td>
 </tr>`).join('');
@@ -1426,7 +1481,7 @@ function renderW3rList(file: W3rFile): string {
 }
 
 function renderW3rEditor(doc: W3rDocument, fileName: string): string {
-    return renderEditableListPage(fileName, `WC3 regions — v${doc.file.version}`, doc.file.regions.length, 'regions', renderW3rList(doc.file), 'Bounds are map coordinates. Weather uses a four-character WC3 environment id.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
+    return renderEditableListPage(fileName, `WC3 regions — v${doc.file.version}`, doc.file.regions.length, 'regions', renderW3rList(doc.file, doc.wtsTable, doc.wtsEdits), 'Bounds are map coordinates. Weather uses a four-character WC3 environment id.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
 .w3r-table { min-width: 1250px; }
 .w3r-table th:nth-child(1) { width: 42px; }.w3r-table th:nth-child(2) { width: 180px; }.w3r-table th:nth-child(n+3):nth-child(-n+8) { width: 100px; }.w3r-table th:nth-child(9) { width: 170px; }.w3r-table th:nth-child(10) { width: 70px; }
 `);
@@ -1434,7 +1489,8 @@ function renderW3rEditor(doc: W3rDocument, fileName: string): string {
 
 class W3rDocument implements vscode.CustomDocument {
     currentRevision = 0; savedRevision = 0; nextRevision = 1; webview?: vscode.Webview;
-    constructor(readonly uri: vscode.Uri, public file: W3rFile) {}
+    wtsEdits = new Map<number, string>();
+    constructor(readonly uri: vscode.Uri, public file: W3rFile, public wtsTable: TriggerStringTable, public wtsUri: vscode.Uri | undefined, public wtsExists: boolean) {}
     dispose(): void {}
 }
 
@@ -1445,7 +1501,8 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
     readonly onDidChangeCustomDocument = this._onDidChange.event;
     async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<W3rDocument> {
         const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
-        const doc = new W3rDocument(uri, parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        const { uri: wtsUri, exists } = findWtsUri(uri);
+        const doc = new W3rDocument(uri, parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(source))), loadTriggerStringsForUri(uri), wtsUri, exists);
         if (openContext.backupId) { doc.currentRevision = 1; doc.nextRevision = 2; }
         return doc;
     }
@@ -1478,7 +1535,11 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
     private removeRegion(doc: W3rDocument, index: number): void { const removed = { ...doc.file.regions[index] }; this.pushEdit(doc, 'Remove region', { apply: () => { doc.file.regions.splice(index, 1); }, revert: () => { doc.file.regions.splice(index, 0, removed); } }); }
     private editRegionField(doc: W3rDocument, index: number, field: string, rawValue: string): void {
         const before = { ...doc.file.regions[index] }; const after = { ...before };
-        if (field === 'name' || field === 'weatherId' || field === 'sound') {
+        if (field === 'name' || field === 'sound') {
+            const triggerEdit = makeTriggerStringEdit(before[field], doc.wtsTable, doc.wtsEdits, rawValue);
+            if (triggerEdit) return this.pushEdit(doc, `Edit region ${field}`, triggerEdit);
+            after[field] = rawValue;
+        } else if (field === 'weatherId') {
             after[field] = rawValue;
         } else if (field === 'color') {
             const color = parseMmpColor(rawValue);
@@ -1486,7 +1547,7 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
             Object.assign(after, color);
         } else if (W3R_NUMERIC_FIELDS.has(field as keyof W3rRegion)) {
             const value = Number(rawValue);
-            if (!Number.isFinite(value) || (field === 'index' && !Number.isInteger(value))) return;
+            if (!Number.isFinite(value) || !Number.isFinite(Math.fround(value)) || (field === 'index' && !Number.isInteger(value))) return;
             after[field as keyof W3rRegion] = value as never;
         } else {
             return;
@@ -1495,11 +1556,11 @@ class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
         this.pushEdit(doc, `Edit region ${field}`, { apply: () => { doc.file.regions[index] = { ...after }; }, revert: () => { doc.file.regions[index] = { ...before }; } });
     }
     private pushEdit(doc: W3rDocument, label: string, edit: W3rEdit): void { const before = doc.currentRevision; const after = doc.nextRevision++; edit.apply(); doc.currentRevision = after; this.postState(doc); this._onDidChange.fire({ document: doc, label, undo: () => { edit.revert(); doc.currentRevision = before; this.postState(doc); }, redo: () => { edit.apply(); doc.currentRevision = after; this.postState(doc); } }); }
-    private postState(doc: W3rDocument): void { void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3rList(doc.file), count: doc.file.regions.length, isDirty: doc.currentRevision !== doc.savedRevision }); }
-    async saveCustomDocument(doc: W3rDocument): Promise<void> { await this.write(doc, doc.uri); doc.savedRevision = doc.currentRevision; this.postState(doc); }
-    async saveCustomDocumentAs(doc: W3rDocument, target: vscode.Uri): Promise<void> { await vscode.workspace.fs.writeFile(target, serializeValidatedW3r(doc.file, target.path)); }
+    private postState(doc: W3rDocument): void { void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3rList(doc.file, doc.wtsTable, doc.wtsEdits), count: doc.file.regions.length, isDirty: doc.currentRevision !== doc.savedRevision }); }
+    async saveCustomDocument(doc: W3rDocument): Promise<void> { await this.write(doc, doc.uri); await writeTriggerStringEdits(doc.wtsEdits, doc.wtsUri, doc.wtsExists); doc.savedRevision = doc.currentRevision; this.postState(doc); }
+    async saveCustomDocumentAs(doc: W3rDocument, target: vscode.Uri): Promise<void> { await vscode.workspace.fs.writeFile(target, serializeValidatedW3r(doc.file, target.path)); const { uri, exists } = findWtsUri(target); await writeTriggerStringEdits(doc.wtsEdits, uri, exists); }
     private async write(doc: W3rDocument, uri: vscode.Uri): Promise<void> { const bytes = serializeValidatedW3r(doc.file, uri.path); try { if (Buffer.from(await vscode.workspace.fs.readFile(uri)).equals(bytes)) return; } catch { /* missing → write */ } await vscode.workspace.fs.writeFile(uri, bytes); }
-    async revertCustomDocument(doc: W3rDocument): Promise<void> { doc.file = parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri))); doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview); }
+    async revertCustomDocument(doc: W3rDocument): Promise<void> { doc.file = parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri))); doc.wtsTable = loadTriggerStringsForUri(doc.uri); doc.wtsEdits.clear(); const { uri, exists } = findWtsUri(doc.uri); doc.wtsUri = uri; doc.wtsExists = exists; doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview); }
     async backupCustomDocument(doc: W3rDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> { await vscode.workspace.fs.writeFile(context.destination, serializeValidatedW3r(doc.file, doc.uri.path)); return { id: context.destination.toString(), delete: () => vscode.workspace.fs.delete(context.destination).then(() => undefined, () => undefined) }; }
 }
 

--- a/src/features/mapDataPreview.ts
+++ b/src/features/mapDataPreview.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { BinReader, parseW3i as parseW3iFile, serializeW3i, W3iFile, W3iPlayer, W3iForce } from 'casc-ts/formats';
+import { BinReader, BinWriter, parseW3i as parseW3iFile, serializeW3i, W3iFile, W3iPlayer, W3iForce } from 'casc-ts/formats';
 import { ParsedPreviewContext, registerParsedPreviewer } from './preview/framework';
 import {
     loadTriggerStringsForUri, resolveTriggerString, ResolvedText, TriggerStringTable,
@@ -18,20 +18,29 @@ import { showErrorWithLogs, showWarningWithLogs } from './diagnostics';
 
 type MapDataFile =
     | { kind: 'imp'; version: number; imports: ImpEntry[]; error?: string }
-    | { kind: 'mmp'; version: number; icons: MmpIcon[]; error?: string }
+    | ({ kind: 'mmp' } & MmpFile)
     | { kind: 'shd'; width: number; height: number; bytes: Buffer; min: number; max: number; dimensionsSource: string; error?: string }
-    | { kind: 'w3c'; version: number; cameras: W3cCamera[]; error?: string }
+    | ({ kind: 'w3c' } & W3cFile)
     | { kind: 'w3i'; info: W3iInfo; error?: string }
-    | { kind: 'w3r'; version: number; regions: W3rRegion[]; error?: string }
+    | ({ kind: 'w3r' } & W3rFile)
     | { kind: 'w3e'; info: W3eInfo; error?: string }
     | { kind: 'generic'; label: string; bytes: Buffer; note: string; error?: string };
 
 interface MmpIcon {
     type: number;
-    label: string;
     x: number;
     y: number;
-    color: string | null;
+    blue: number;
+    green: number;
+    red: number;
+    alpha: number;
+}
+
+interface MmpFile {
+    version: number;
+    icons: MmpIcon[];
+    tail: Buffer;
+    error?: string;
 }
 
 interface ImpEntry {
@@ -54,6 +63,13 @@ interface W3cCamera {
     farZ: number;
     unknown: number;
     name: string;
+}
+
+interface W3cFile {
+    version: number;
+    cameras: W3cCamera[];
+    tail: Buffer;
+    error?: string;
 }
 
 interface W3iInfo {
@@ -95,7 +111,17 @@ interface W3rRegion {
     maxY: number;
     weatherId: string;
     sound: string;
-    color: string;
+    blue: number;
+    green: number;
+    red: number;
+    endToken: number;
+}
+
+interface W3rFile {
+    version: number;
+    regions: W3rRegion[];
+    tail: Buffer;
+    error?: string;
 }
 
 interface W3eInfo {
@@ -155,10 +181,17 @@ function parseImp(data: Buffer, fileName: string): MapDataFile {
 }
 
 function parseMmp(data: Buffer): MapDataFile {
+    return { kind: 'mmp', ...parseMmpFile(data) };
+}
+
+function parseMmpFile(data: Buffer): MmpFile {
     const r = new BinReader(data);
     try {
         const version = r.readI32();
         const count = r.readI32();
+        if (count < 0 || count > Math.floor(r.remaining / 16)) {
+            throw new Error(`Invalid MMP icon count ${count}.`);
+        }
         const icons: MmpIcon[] = [];
         for (let i = 0; i < count; i++) {
             const type = r.readI32();
@@ -168,14 +201,11 @@ function parseMmp(data: Buffer): MapDataFile {
             const green = r.readU8();
             const red = r.readU8();
             const alpha = r.readU8();
-            const color = blue === 0xff && green === 0xff && red === 0xff && alpha === 0xff
-                ? null
-                : `rgba(${red},${green},${blue},${(alpha / 255).toFixed(3)})`;
-            icons.push({ type, label: mmpIconLabel(type), x, y, color });
+            icons.push({ type, x, y, blue, green, red, alpha });
         }
-        return { kind: 'mmp', version, icons };
+        return { version, icons, tail: r.remaining ? Buffer.from(r.readBytes(r.remaining)) : Buffer.alloc(0) };
     } catch (e) {
-        return { kind: 'mmp', version: 0, icons: [], error: errorMessage(e) };
+        return { version: 0, icons: [], tail: Buffer.alloc(0), error: errorMessage(e) };
     }
 }
 
@@ -263,10 +293,15 @@ function factorDimensions(byteLength: number): { width: number; height: number }
 }
 
 function parseW3c(data: Buffer): MapDataFile {
+    return { kind: 'w3c', ...parseW3cFile(data) };
+}
+
+function parseW3cFile(data: Buffer): W3cFile {
     const r = new BinReader(data);
     try {
         const version = r.readI32();
         const count = r.readI32();
+        if (count < 0 || count > Math.floor(r.remaining / 41)) throw new Error(`Invalid W3C camera count ${count}.`);
         const cameras: W3cCamera[] = [];
         for (let i = 0; i < count; i++) {
             cameras.push({
@@ -283,9 +318,9 @@ function parseW3c(data: Buffer): MapDataFile {
                 name: r.readString(),
             });
         }
-        return { kind: 'w3c', version, cameras };
+        return { version, cameras, tail: r.remaining ? Buffer.from(r.readBytes(r.remaining)) : Buffer.alloc(0) };
     } catch (e) {
-        return { kind: 'w3c', version: 0, cameras: [], error: errorMessage(e) };
+        return { version: 0, cameras: [], tail: Buffer.alloc(0), error: errorMessage(e) };
     }
 }
 
@@ -370,10 +405,15 @@ function parseW3i(data: Buffer): MapDataFile {
 }
 
 function parseW3r(data: Buffer): MapDataFile {
+    return { kind: 'w3r', ...parseW3rFile(data) };
+}
+
+function parseW3rFile(data: Buffer): W3rFile {
     const r = new BinReader(data);
     try {
         const version = r.readI32();
         const count = r.readI32();
+        if (count < 0 || count > Math.floor(r.remaining / 30)) throw new Error(`Invalid W3R region count ${count}.`);
         const regions: W3rRegion[] = [];
         for (let i = 0; i < count; i++) {
             const minX = r.readF32();
@@ -387,12 +427,12 @@ function parseW3r(data: Buffer): MapDataFile {
             const blue = r.readU8();
             const green = r.readU8();
             const red = r.readU8();
-            r.readU8(); // end token
-            regions.push({ name, index, minX, maxX, minY, maxY, weatherId, sound, color: `rgb(${red},${green},${blue})` });
+            const endToken = r.readU8();
+            regions.push({ name, index, minX, maxX, minY, maxY, weatherId, sound, blue, green, red, endToken });
         }
-        return { kind: 'w3r', version, regions };
+        return { version, regions, tail: r.remaining ? Buffer.from(r.readBytes(r.remaining)) : Buffer.alloc(0) };
     } catch (e) {
-        return { kind: 'w3r', version: 0, regions: [], error: errorMessage(e) };
+        return { version: 0, regions: [], tail: Buffer.alloc(0), error: errorMessage(e) };
     }
 }
 
@@ -685,10 +725,10 @@ ${parsed.imports.length ? `<div class="table-wrap"><table><thead><tr><th>#</th><
 function renderMmp(parsed: Extract<MapDataFile, { kind: 'mmp' }>, fileName: string): string {
     const rows = parsed.icons.map((icon, index) => `<tr>
   <td class="num">${index}</td>
-  <td>${escapeHtml(icon.label)}</td>
+  <td>${escapeHtml(mmpIconLabel(icon.type))}</td>
   <td class="num">${icon.x}</td>
   <td class="num">${icon.y}</td>
-  <td>${icon.color ? `<span class="swatch" style="background:${icon.color}"></span>${escapeHtml(icon.color)}` : '<span class="empty">default</span>'}</td>
+  <td>${mmpColorCss(icon) ? `<span class="swatch" style="background:${mmpColorCss(icon)}"></span>${escapeHtml(mmpColorCss(icon) as string)}` : '<span class="empty">default</span>'}</td>
 </tr>`).join('');
     return page(fileName, `
 ${renderHeader(fileName, `WC3 minimap icons - v${parsed.version}`)}
@@ -831,7 +871,7 @@ function renderW3r(parsed: Extract<MapDataFile, { kind: 'w3r' }>, fileName: stri
   <td class="num">${fmt(region.maxY)}</td>
   <td class="mono">${escapeHtml(region.weatherId || '-')}</td>
   <td>${renderResolvedInline(resolveTriggerString(region.sound || '-', triggerStrings))}</td>
-  <td><span class="swatch" style="background:${region.color}"></span>${escapeHtml(region.color)}</td>
+  <td><span class="swatch" style="background:${w3rColorCss(region)}"></span>${escapeHtml(w3rColorCss(region))}</td>
 </tr>`).join('');
     return page(fileName, `
 ${renderHeader(fileName, `WC3 regions - v${parsed.version}`)}
@@ -1044,11 +1084,28 @@ function errorBanner(error?: string): string {
     return error ? `<div class="error">${escapeHtml(error)}</div>` : '';
 }
 
+const MMP_ICON_TYPES: Array<[number, string]> = [
+    [0, 'Gold Mine'],
+    [1, 'Neutral Building / House'],
+    [2, 'Player Start'],
+];
+
 function mmpIconLabel(type: number): string {
-    if (type === 0) return 'Gold Mine';
-    if (type === 1) return 'Neutral Building';
-    if (type === 2) return 'Player Start';
-    return `Unknown (${type})`;
+    return MMP_ICON_TYPES.find(([value]) => value === type)?.[1] ?? `Unknown / custom (${type})`;
+}
+
+function mmpIconTypeOptions(type: number): Array<[number, string]> {
+    if (MMP_ICON_TYPES.some(([value]) => value === type)) return MMP_ICON_TYPES;
+    return [[type, `Unknown / custom (${type})`], ...MMP_ICON_TYPES];
+}
+
+function mmpColorCss(icon: MmpIcon): string | null {
+    if (icon.blue === 0xff && icon.green === 0xff && icon.red === 0xff && icon.alpha === 0xff) return null;
+    return `rgba(${icon.red},${icon.green},${icon.blue},${(icon.alpha / 255).toFixed(3)})`;
+}
+
+function mmpColorHex(icon: MmpIcon): string {
+    return `#${icon.red.toString(16).padStart(2, '0')}${icon.green.toString(16).padStart(2, '0')}${icon.blue.toString(16).padStart(2, '0')}`;
 }
 
 function graphicsLabel(value: number): string {
@@ -1080,6 +1137,695 @@ function fmt(value: number): string {
 
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+}
+
+function w3rColorCss(region: W3rRegion): string {
+    return `rgb(${region.red},${region.green},${region.blue})`;
+}
+
+function colorHex(red: number, green: number, blue: number): string {
+    return `#${red.toString(16).padStart(2, '0')}${green.toString(16).padStart(2, '0')}${blue.toString(16).padStart(2, '0')}`;
+}
+
+const EDITABLE_LIST_CSS = `
+.editable-list { max-width: 1500px; }
+.editable-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; margin: 3px 0 10px; }
+.action-button, .remove-button {
+  color: var(--btn-fg, var(--fg)); background: var(--btn-bg, var(--input-bg));
+  border: 1px solid var(--border); border-radius: 3px; padding: 4px 9px;
+  font: inherit; font-size: 12px; cursor: pointer;
+}
+.action-button:hover, .remove-button:hover { background: var(--btn-hover, var(--hover)); }
+.remove-button { color: var(--vscode-errorForeground, #f14c4c); background: transparent; padding: 3px 7px; }
+.edit-table { min-width: 1100px; table-layout: fixed; }
+.edit-table th { white-space: nowrap; }
+.edit-table th:last-child { width: 84px; }
+.edit-table td { vertical-align: middle; }
+.list-input { width: 100%; min-width: 0; height: 26px; padding: 3px 6px; color: var(--input-fg); background: var(--input-bg); border: 1px solid var(--input-border, var(--border)); border-radius: 2px; font: inherit; }
+.list-input:focus, .list-color:focus { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
+.list-input.mono { font-family: var(--mono); }
+.list-color { width: 34px; height: 26px; padding: 1px; border: 1px solid var(--input-border, var(--border)); background: var(--input-bg); border-radius: 2px; }
+.edit-table .num { white-space: nowrap; }
+.edit-table .row-number { width: 42px; }
+.edit-table .color-cell { text-align: center; }
+.dirty-badge[hidden] { display: none; }
+`;
+
+const EDITABLE_LIST_SCRIPT = `<script>
+(function () {
+  const api = acquireVsCodeApi();
+  document.addEventListener('change', function (e) {
+    const t = e.target;
+    if (t.matches('[data-field]')) {
+      api.postMessage({ type: 'edit', index: Number(t.getAttribute('data-index')), field: t.getAttribute('data-field'), value: t.value });
+    }
+  });
+  document.addEventListener('click', function (e) {
+    const remove = e.target.closest('[data-remove]');
+    if (remove) api.postMessage({ type: 'remove', index: Number(remove.getAttribute('data-remove')) });
+    else if (e.target.closest('[data-add]')) api.postMessage({ type: 'add' });
+  });
+  window.addEventListener('message', function (event) {
+    const msg = event.data || {};
+    if (msg.type !== 'editorStateChanged') return;
+    const list = document.getElementById('editorList');
+    const count = document.getElementById('editorCount');
+    const badge = document.getElementById('dirtyBadge');
+    if (list) list.innerHTML = msg.listHtml;
+    if (count) count.textContent = String(msg.count);
+    if (badge) badge.hidden = !msg.isDirty;
+  });
+})();
+</script>`;
+
+function renderEditableListPage(
+    fileName: string,
+    meta: string,
+    count: number,
+    countLabel: string,
+    listHtml: string,
+    hint: string,
+    isDirty: boolean,
+    extraCss: string,
+): string {
+    const body = `
+${renderHeader(fileName, meta, true)}
+<div class="dialog editable-list">
+<div class="metric-strip"><span class="metric"><strong id="editorCount">${count}</strong> ${countLabel}</span></div>
+<div class="editable-actions">
+  <button type="button" class="action-button" data-add>Add ${countLabel.slice(0, -1)}</button>
+  <span class="hint">${escapeHtml(hint)}</span>
+</div>
+<div id="editorList">${listHtml}</div>
+</div>
+${EDITABLE_LIST_SCRIPT}`;
+    return page(fileName, body.replace('id="dirtyBadge" hidden', `id="dirtyBadge"${isDirty ? '' : ' hidden'}`), extraCss, true);
+}
+
+const W3C_NUMERIC_FIELDS = new Set<keyof W3cCamera>([
+    'targetX', 'targetY', 'zOffset', 'rotation', 'angleOfAttack', 'distance', 'roll', 'fieldOfView', 'farZ', 'unknown',
+]);
+
+function w3cCameraInput(camera: W3cCamera, index: number, field: keyof W3cCamera, className = ''): string {
+    const value = field === 'name' ? camera.name : fmt(camera[field] as number);
+    const type = field === 'name' ? 'text' : 'number';
+    const step = field === 'name' ? '' : ' step="any"';
+    return `<input class="list-input ${className}" type="${type}"${step} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Camera ${index + 1} ${field}">`;
+}
+
+function renderW3cList(file: W3cFile): string {
+    if (!file.cameras.length) return '<p class="empty">No cameras. Add one to create a camera record.</p>';
+    const rows = file.cameras.map((camera, index) => `<tr data-row="${index}">
+  <td class="num row-number">${index + 1}</td>
+  <td>${w3cCameraInput(camera, index, 'name')}</td>
+  <td>${w3cCameraInput(camera, index, 'targetX', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'targetY', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'zOffset', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'rotation', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'angleOfAttack', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'distance', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'roll', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'fieldOfView', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'farZ', 'mono')}</td>
+  <td>${w3cCameraInput(camera, index, 'unknown', 'mono')}</td>
+  <td><button type="button" class="remove-button" data-remove="${index}">Remove</button></td>
+</tr>`).join('');
+    return `<div class="table-wrap"><table class="edit-table w3c-table"><thead><tr><th>#</th><th>Name</th><th>Target X</th><th>Target Y</th><th>Z offset</th><th>Rotation</th><th>Angle of attack</th><th>Distance</th><th>Roll</th><th>Field of view</th><th>Far Z</th><th>Unknown</th><th></th></tr></thead><tbody>${rows}</tbody></table></div>`;
+}
+
+function renderW3cEditor(doc: W3cDocument, fileName: string): string {
+    return renderEditableListPage(fileName, `WC3 cameras — v${doc.file.version}`, doc.file.cameras.length, 'cameras', renderW3cList(doc.file), 'Camera values are stored as floating-point Warcraft III camera parameters.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
+.w3c-table { min-width: 1500px; }
+.w3c-table th:nth-child(1) { width: 42px; }.w3c-table th:nth-child(2) { width: 180px; }.w3c-table th:nth-child(n+3):nth-child(-n+12) { width: 110px; }
+`);
+}
+
+class W3cDocument implements vscode.CustomDocument {
+    currentRevision = 0;
+    savedRevision = 0;
+    nextRevision = 1;
+    webview?: vscode.Webview;
+    constructor(readonly uri: vscode.Uri, public file: W3cFile) {}
+    dispose(): void {}
+}
+
+interface W3cEdit { apply: () => void; revert: () => void; }
+
+class W3cEditorProvider implements vscode.CustomEditorProvider<W3cDocument> {
+    private readonly _onDidChange = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<W3cDocument>>();
+    readonly onDidChangeCustomDocument = this._onDidChange.event;
+
+    async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<W3cDocument> {
+        const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
+        const doc = new W3cDocument(uri, parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        if (openContext.backupId) { doc.currentRevision = 1; doc.nextRevision = 2; }
+        return doc;
+    }
+
+    async resolveCustomEditor(doc: W3cDocument, panel: vscode.WebviewPanel): Promise<void> {
+        panel.webview.options = { enableScripts: true, localResourceRoots: [] };
+        doc.webview = panel.webview;
+        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
+        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
+        this.render(doc, panel.webview);
+    }
+
+    private render(doc: W3cDocument, webview: vscode.Webview): void {
+        const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);
+        webview.html = doc.file.error
+            ? buildPage({ csp: "default-src 'none'; style-src 'unsafe-inline';", title: escapeHtml(fileName), body: `<div class="wv-state"><span>Failed to parse W3C cameras</span><span class="err">${escapeHtml(doc.file.error)}</span></div>` })
+            : renderW3cEditor(doc, fileName);
+    }
+
+    private handleMessage(message: unknown, doc: W3cDocument): void {
+        if (!message || typeof message !== 'object' || doc.file.error) return;
+        const msg = message as { type?: string; index?: number; field?: string; value?: string };
+        if (msg.type === 'add') return this.addCamera(doc);
+        if (!this.validIndex(msg.index, doc.file.cameras.length)) return;
+        const index = msg.index as number;
+        if (msg.type === 'remove') return this.removeCamera(doc, index);
+        if (msg.type === 'edit' && typeof msg.field === 'string' && typeof msg.value === 'string') this.editCameraField(doc, index, msg.field, msg.value);
+    }
+
+    private validIndex(index: number | undefined, length: number): index is number {
+        return Number.isInteger(index) && (index as number) >= 0 && (index as number) < length;
+    }
+
+    private addCamera(doc: W3cDocument): void {
+        const camera: W3cCamera = { targetX: 0, targetY: 0, zOffset: 0, rotation: 270, angleOfAttack: 304, distance: 1650, roll: 0, fieldOfView: 70, farZ: 5000, unknown: 0, name: 'New Camera' };
+        const index = doc.file.cameras.length;
+        this.pushEdit(doc, 'Add camera', { apply: () => { doc.file.cameras.push(camera); }, revert: () => { doc.file.cameras.splice(index, 1); } });
+    }
+
+    private removeCamera(doc: W3cDocument, index: number): void {
+        const removed = { ...doc.file.cameras[index] };
+        this.pushEdit(doc, 'Remove camera', { apply: () => { doc.file.cameras.splice(index, 1); }, revert: () => { doc.file.cameras.splice(index, 0, removed); } });
+    }
+
+    private editCameraField(doc: W3cDocument, index: number, field: string, rawValue: string): void {
+        const before = { ...doc.file.cameras[index] };
+        const after = { ...before };
+        if (field === 'name') after.name = rawValue;
+        else if (W3C_NUMERIC_FIELDS.has(field as keyof W3cCamera)) {
+            const value = Number(rawValue);
+            if (!Number.isFinite(value)) return;
+            after[field as keyof W3cCamera] = value as never;
+        } else return;
+        if (JSON.stringify(before) === JSON.stringify(after)) return;
+        this.pushEdit(doc, `Edit camera ${field}`, { apply: () => { doc.file.cameras[index] = { ...after }; }, revert: () => { doc.file.cameras[index] = { ...before }; } });
+    }
+
+    private pushEdit(doc: W3cDocument, label: string, edit: W3cEdit): void {
+        const beforeRevision = doc.currentRevision;
+        const afterRevision = doc.nextRevision++;
+        edit.apply(); doc.currentRevision = afterRevision; this.postState(doc);
+        this._onDidChange.fire({ document: doc, label, undo: () => { edit.revert(); doc.currentRevision = beforeRevision; this.postState(doc); }, redo: () => { edit.apply(); doc.currentRevision = afterRevision; this.postState(doc); } });
+    }
+
+    private postState(doc: W3cDocument): void {
+        void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3cList(doc.file), count: doc.file.cameras.length, isDirty: doc.currentRevision !== doc.savedRevision });
+    }
+
+    async saveCustomDocument(doc: W3cDocument): Promise<void> {
+        await this.write(doc, doc.uri);
+        doc.savedRevision = doc.currentRevision;
+        this.postState(doc);
+    }
+
+    async saveCustomDocumentAs(doc: W3cDocument, target: vscode.Uri): Promise<void> { await vscode.workspace.fs.writeFile(target, serializeValidatedW3c(doc.file, target.path)); }
+
+    private async write(doc: W3cDocument, uri: vscode.Uri): Promise<void> {
+        const bytes = serializeValidatedW3c(doc.file, uri.path);
+        try { if (Buffer.from(await vscode.workspace.fs.readFile(uri)).equals(bytes)) return; } catch { /* missing → write */ }
+        await vscode.workspace.fs.writeFile(uri, bytes);
+    }
+
+    async revertCustomDocument(doc: W3cDocument): Promise<void> { doc.file = parseW3cFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri))); doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview); }
+
+    async backupCustomDocument(doc: W3cDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> {
+        await vscode.workspace.fs.writeFile(context.destination, serializeValidatedW3c(doc.file, doc.uri.path));
+        return { id: context.destination.toString(), delete: () => vscode.workspace.fs.delete(context.destination).then(() => undefined, () => undefined) };
+    }
+}
+
+function serializeW3c(file: W3cFile): Buffer {
+    const w = new BinWriter(8 + file.cameras.length * 48 + file.tail.length);
+    w.writeI32(file.version); w.writeI32(file.cameras.length);
+    for (const camera of file.cameras) {
+        w.writeF32(camera.targetX); w.writeF32(camera.targetY); w.writeF32(camera.zOffset); w.writeF32(camera.rotation);
+        w.writeF32(camera.angleOfAttack); w.writeF32(camera.distance); w.writeF32(camera.roll); w.writeF32(camera.fieldOfView);
+        w.writeF32(camera.farZ); w.writeF32(camera.unknown); w.writeString(camera.name);
+    }
+    w.writeBytes(file.tail); return w.toBuffer();
+}
+
+function serializeValidatedW3c(file: W3cFile, name: string): Buffer {
+    if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
+    const reparsed = parseW3cFile(serializeW3c(file));
+    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.cameras.length !== file.cameras.length || reparsed.cameras.some((camera, i) => JSON.stringify(camera) !== JSON.stringify(file.cameras[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    return serializeW3c(file);
+}
+
+const W3R_NUMERIC_FIELDS = new Set<keyof W3rRegion>(['minX', 'maxX', 'minY', 'maxY', 'index']);
+
+function w3rRegionInput(region: W3rRegion, index: number, field: keyof W3rRegion, className = ''): string {
+    const value = field === 'name' || field === 'weatherId' || field === 'sound' ? region[field] as string : fmt(region[field] as number);
+    const type = field === 'name' || field === 'weatherId' || field === 'sound' ? 'text' : 'number';
+    const step = type === 'number' && field !== 'index' ? ' step="any"' : '';
+    const maxLength = field === 'weatherId' ? ' maxlength="4"' : '';
+    return `<input class="list-input ${className}" type="${type}"${step}${maxLength} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Region ${index + 1} ${field}">`;
+}
+
+function renderW3rList(file: W3rFile): string {
+    if (!file.regions.length) return '<p class="empty">No regions. Add one to create a region record.</p>';
+    const rows = file.regions.map((region, index) => `<tr data-row="${index}">
+  <td class="num row-number">${index + 1}</td>
+  <td>${w3rRegionInput(region, index, 'name')}</td>
+  <td>${w3rRegionInput(region, index, 'minX', 'mono')}</td><td>${w3rRegionInput(region, index, 'maxX', 'mono')}</td>
+  <td>${w3rRegionInput(region, index, 'minY', 'mono')}</td><td>${w3rRegionInput(region, index, 'maxY', 'mono')}</td>
+  <td>${w3rRegionInput(region, index, 'index', 'mono')}</td>
+  <td>${w3rRegionInput(region, index, 'weatherId', 'mono')}</td><td>${w3rRegionInput(region, index, 'sound')}</td>
+  <td class="color-cell"><input class="list-color" type="color" data-index="${index}" data-field="color" value="${colorHex(region.red, region.green, region.blue)}" aria-label="Region ${index + 1} color"></td>
+  <td><button type="button" class="remove-button" data-remove="${index}">Remove</button></td>
+</tr>`).join('');
+    return `<div class="table-wrap"><table class="edit-table w3r-table"><thead><tr><th>#</th><th>Name</th><th>Min X</th><th>Max X</th><th>Min Y</th><th>Max Y</th><th>Index</th><th>Weather</th><th>Sound</th><th>Color</th><th></th></tr></thead><tbody>${rows}</tbody></table></div>`;
+}
+
+function renderW3rEditor(doc: W3rDocument, fileName: string): string {
+    return renderEditableListPage(fileName, `WC3 regions — v${doc.file.version}`, doc.file.regions.length, 'regions', renderW3rList(doc.file), 'Bounds are map coordinates. Weather uses a four-character WC3 environment id.', doc.currentRevision !== doc.savedRevision, `${EDITABLE_LIST_CSS}
+.w3r-table { min-width: 1250px; }
+.w3r-table th:nth-child(1) { width: 42px; }.w3r-table th:nth-child(2) { width: 180px; }.w3r-table th:nth-child(n+3):nth-child(-n+8) { width: 100px; }.w3r-table th:nth-child(9) { width: 170px; }.w3r-table th:nth-child(10) { width: 70px; }
+`);
+}
+
+class W3rDocument implements vscode.CustomDocument {
+    currentRevision = 0; savedRevision = 0; nextRevision = 1; webview?: vscode.Webview;
+    constructor(readonly uri: vscode.Uri, public file: W3rFile) {}
+    dispose(): void {}
+}
+
+interface W3rEdit { apply: () => void; revert: () => void; }
+
+class W3rEditorProvider implements vscode.CustomEditorProvider<W3rDocument> {
+    private readonly _onDidChange = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<W3rDocument>>();
+    readonly onDidChangeCustomDocument = this._onDidChange.event;
+    async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<W3rDocument> {
+        const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
+        const doc = new W3rDocument(uri, parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        if (openContext.backupId) { doc.currentRevision = 1; doc.nextRevision = 2; }
+        return doc;
+    }
+    async resolveCustomEditor(doc: W3rDocument, panel: vscode.WebviewPanel): Promise<void> {
+        panel.webview.options = { enableScripts: true, localResourceRoots: [] }; doc.webview = panel.webview;
+        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
+        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc)); this.render(doc, panel.webview);
+    }
+    private render(doc: W3rDocument, webview: vscode.Webview): void {
+        const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);
+        webview.html = doc.file.error ? buildPage({ csp: "default-src 'none'; style-src 'unsafe-inline';", title: escapeHtml(fileName), body: `<div class="wv-state"><span>Failed to parse W3R regions</span><span class="err">${escapeHtml(doc.file.error)}</span></div>` }) : renderW3rEditor(doc, fileName);
+    }
+    private handleMessage(message: unknown, doc: W3rDocument): void {
+        if (!message || typeof message !== 'object' || doc.file.error) return;
+        const msg = message as { type?: string; index?: number; field?: string; value?: string };
+        if (msg.type === 'add') return this.addRegion(doc);
+        if (!this.validIndex(msg.index, doc.file.regions.length)) return;
+        const index = msg.index as number;
+        if (msg.type === 'remove') return this.removeRegion(doc, index);
+        if (msg.type === 'edit' && typeof msg.field === 'string' && typeof msg.value === 'string') this.editRegionField(doc, index, msg.field, msg.value);
+    }
+    private validIndex(index: number | undefined, length: number): index is number { return Number.isInteger(index) && (index as number) >= 0 && (index as number) < length; }
+    private addRegion(doc: W3rDocument): void {
+        const region: W3rRegion = { name: 'New Region', minX: 0, maxX: 128, minY: 0, maxY: 128, index: 0, weatherId: 'NULL', sound: '', blue: 0, green: 0, red: 0, endToken: 0 };
+        const index = doc.file.regions.length; this.pushEdit(doc, 'Add region', { apply: () => { doc.file.regions.push(region); }, revert: () => { doc.file.regions.splice(index, 1); } });
+    }
+    private removeRegion(doc: W3rDocument, index: number): void { const removed = { ...doc.file.regions[index] }; this.pushEdit(doc, 'Remove region', { apply: () => { doc.file.regions.splice(index, 1); }, revert: () => { doc.file.regions.splice(index, 0, removed); } }); }
+    private editRegionField(doc: W3rDocument, index: number, field: string, rawValue: string): void {
+        const before = { ...doc.file.regions[index] }; const after = { ...before };
+        if (field === 'name' || field === 'weatherId' || field === 'sound') after[field] = rawValue;
+        else if (field === 'color') { const color = parseMmpColor(rawValue); if (!color) return; Object.assign(after, color); }
+        else if (W3R_NUMERIC_FIELDS.has(field as keyof W3rRegion)) { const value = Number(rawValue); if (!Number.isFinite(value) || (field === 'index' && !Number.isInteger(value))) return; after[field as keyof W3rRegion] = value as never; }
+        else return;
+        if (JSON.stringify(before) === JSON.stringify(after)) return;
+        this.pushEdit(doc, `Edit region ${field}`, { apply: () => { doc.file.regions[index] = { ...after }; }, revert: () => { doc.file.regions[index] = { ...before }; } });
+    }
+    private pushEdit(doc: W3rDocument, label: string, edit: W3rEdit): void { const before = doc.currentRevision; const after = doc.nextRevision++; edit.apply(); doc.currentRevision = after; this.postState(doc); this._onDidChange.fire({ document: doc, label, undo: () => { edit.revert(); doc.currentRevision = before; this.postState(doc); }, redo: () => { edit.apply(); doc.currentRevision = after; this.postState(doc); } }); }
+    private postState(doc: W3rDocument): void { void doc.webview?.postMessage({ type: 'editorStateChanged', listHtml: renderW3rList(doc.file), count: doc.file.regions.length, isDirty: doc.currentRevision !== doc.savedRevision }); }
+    async saveCustomDocument(doc: W3rDocument): Promise<void> { await this.write(doc, doc.uri); doc.savedRevision = doc.currentRevision; this.postState(doc); }
+    async saveCustomDocumentAs(doc: W3rDocument, target: vscode.Uri): Promise<void> { await vscode.workspace.fs.writeFile(target, serializeValidatedW3r(doc.file, target.path)); }
+    private async write(doc: W3rDocument, uri: vscode.Uri): Promise<void> { const bytes = serializeValidatedW3r(doc.file, uri.path); try { if (Buffer.from(await vscode.workspace.fs.readFile(uri)).equals(bytes)) return; } catch { /* missing → write */ } await vscode.workspace.fs.writeFile(uri, bytes); }
+    async revertCustomDocument(doc: W3rDocument): Promise<void> { doc.file = parseW3rFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri))); doc.currentRevision = 0; doc.savedRevision = 0; doc.nextRevision = 1; if (doc.webview) this.render(doc, doc.webview); }
+    async backupCustomDocument(doc: W3rDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> { await vscode.workspace.fs.writeFile(context.destination, serializeValidatedW3r(doc.file, doc.uri.path)); return { id: context.destination.toString(), delete: () => vscode.workspace.fs.delete(context.destination).then(() => undefined, () => undefined) }; }
+}
+
+function serializeW3r(file: W3rFile): Buffer {
+    const w = new BinWriter(8 + file.regions.length * 64 + file.tail.length); w.writeI32(file.version); w.writeI32(file.regions.length);
+    for (const region of file.regions) { w.writeF32(region.minX); w.writeF32(region.maxX); w.writeF32(region.minY); w.writeF32(region.maxY); w.writeString(region.name); w.writeI32(region.index); w.writeId(region.weatherId); w.writeString(region.sound); w.writeU8(region.blue); w.writeU8(region.green); w.writeU8(region.red); w.writeU8(region.endToken); }
+    w.writeBytes(file.tail); return w.toBuffer();
+}
+
+function serializeValidatedW3r(file: W3rFile, name: string): Buffer {
+    if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
+    const bytes = serializeW3r(file); const reparsed = parseW3rFile(bytes);
+    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.regions.length !== file.regions.length || reparsed.regions.some((region, i) => JSON.stringify(region) !== JSON.stringify(file.regions[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    return bytes;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Editable .mmp minimap-icon editor
+//
+// MMP is deliberately small: a version, a count, and fixed-size icon records.
+// Keep the opaque tail, if a non-standard file has one, so editing the list does
+// not discard bytes we do not understand.
+// ════════════════════════════════════════════════════════════════════════════
+
+class MmpDocument implements vscode.CustomDocument {
+    currentRevision = 0;
+    savedRevision = 0;
+    nextRevision = 1;
+    webview?: vscode.Webview;
+
+    constructor(readonly uri: vscode.Uri, public file: MmpFile) {}
+
+    dispose(): void {}
+}
+
+interface MmpEdit { apply: () => void; revert: () => void; }
+
+function mmpIconInput(icon: MmpIcon, index: number): string {
+    const defaultColor = !mmpColorCss(icon);
+    const typeOptions = mmpIconTypeOptions(icon.type).map(([value, label]) =>
+        `<option value="${value}"${value === icon.type ? ' selected' : ''}>${escapeHtml(label)}</option>`).join('');
+    const colorDisabled = defaultColor ? ' disabled' : '';
+    return `<tr data-row="${index}">
+  <td class="num row-number">${index + 1}</td>
+  <td><select class="mmp-input mmp-select" data-index="${index}" data-field="type" aria-label="Icon ${index + 1} type">${typeOptions}</select></td>
+  <td><input class="mmp-input mono" type="number" data-index="${index}" data-field="x" value="${icon.x}" aria-label="Icon ${index + 1} X coordinate"></td>
+  <td><input class="mmp-input mono" type="number" data-index="${index}" data-field="y" value="${icon.y}" aria-label="Icon ${index + 1} Y coordinate"></td>
+  <td class="type-label">${escapeHtml(mmpIconLabel(icon.type))}</td>
+  <td class="color-cell">
+    <input class="color-input" type="color" data-index="${index}" data-field="color" value="${mmpColorHex(icon)}" aria-label="Icon ${index + 1} custom color"${colorDisabled}>
+    <input class="alpha-input mmp-input mono" type="number" min="0" max="255" data-index="${index}" data-field="alpha" value="${icon.alpha}" aria-label="Icon ${index + 1} alpha"${colorDisabled}>
+    <label class="default-color"><input type="checkbox" data-index="${index}" data-default-color title="No custom tint; use the normal game icon color"${defaultColor ? ' checked' : ''}> game default</label>
+  </td>
+  <td><button type="button" class="remove-button" data-remove="${index}" title="Remove this minimap icon">Remove</button></td>
+</tr>`;
+}
+
+function renderMmpList(file: MmpFile): string {
+    if (!file.icons.length) return '<p class="empty">No minimap icons. Add one if you want a custom lobby marker.</p>';
+    const rows = file.icons.map((icon, index) => mmpIconInput(icon, index)).join('');
+    return `<div class="table-wrap"><table class="mmp-table"><thead><tr><th>#</th><th>Type</th><th>X</th><th>Y</th><th>Meaning</th><th>Color · alpha</th><th></th></tr></thead><tbody>${rows}</tbody></table></div>`;
+}
+
+function renderMmpEditor(doc: MmpDocument, fileName: string): string {
+    const f = doc.file;
+    const dirty = doc.currentRevision !== doc.savedRevision;
+    const body = `
+${renderHeader(fileName, `WC3 minimap icons — v${f.version}`, true)}
+<div class="dialog mmp-editor">
+${errorBanner(f.error)}
+<div class="metric-strip">
+  <span class="metric"><strong id="mmpCount">${f.icons.length}</strong> icon${f.icons.length === 1 ? '' : 's'}</span>
+  <span class="metric">Records are shown in minimap/lobby order</span>
+</div>
+<div class="mmp-actions">
+  <button type="button" class="action-button" data-add>Add minimap icon</button>
+  <span class="hint">Remove entries to hide them from the lobby minimap preview. Coordinates are Warcraft III map coordinates.</span>
+</div>
+<div id="mmpList">${renderMmpList(f)}</div>
+<p class="hint mmp-footer-hint">Game default color = <code>FF FF FF FF</code>: no custom tint, so Warcraft III uses the icon’s normal color. Uncheck it to choose a custom tint.</p>
+</div>
+<script>
+(function () {
+  const api = acquireVsCodeApi();
+  document.addEventListener('change', function (e) {
+    const t = e.target;
+    if (t.matches('[data-default-color]')) {
+      const row = t.closest('[data-row]');
+      row.querySelectorAll('[data-field="color"], [data-field="alpha"]').forEach(function (control) { control.disabled = t.checked; });
+      api.postMessage({ type: 'defaultColor', index: Number(t.getAttribute('data-index')), on: t.checked });
+      return;
+    }
+    if (t.matches('[data-field]')) {
+      api.postMessage({ type: 'edit', index: Number(t.getAttribute('data-index')), field: t.getAttribute('data-field'), value: t.value });
+    }
+  });
+  document.addEventListener('click', function (e) {
+    const remove = e.target.closest('[data-remove]');
+    if (remove) api.postMessage({ type: 'remove', index: Number(remove.getAttribute('data-remove')) });
+    else if (e.target.closest('[data-add]')) api.postMessage({ type: 'add' });
+  });
+  window.addEventListener('message', function (event) {
+    const msg = event.data || {};
+    if (msg.type === 'mmpStateChanged') {
+      const list = document.getElementById('mmpList');
+      const count = document.getElementById('mmpCount');
+      if (list) list.innerHTML = msg.listHtml;
+      if (count) count.textContent = String(msg.count);
+      const badge = document.getElementById('dirtyBadge');
+      if (badge) badge.hidden = !msg.isDirty;
+    } else if (msg.type === 'dirtyStateChanged') {
+      const badge = document.getElementById('dirtyBadge');
+      if (badge) badge.hidden = !msg.isDirty;
+    }
+  });
+})();
+</script>`;
+    // Keep the value explicit here for the initial render; subsequent renders use the same
+    // revision comparison and therefore keep the badge correct after undo/redo as well.
+    return page(fileName, body.replace('id="dirtyBadge" hidden', `id="dirtyBadge"${dirty ? '' : ' hidden'}`), MMP_EDITOR_CSS, true);
+}
+
+const MMP_EDITOR_CSS = `
+.mmp-editor { max-width: 1180px; }
+.mmp-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; margin: 3px 0 10px; }
+.action-button, .remove-button {
+  color: var(--btn-fg, var(--fg)); background: var(--btn-bg, var(--input-bg));
+  border: 1px solid var(--border); border-radius: 3px; padding: 4px 9px;
+  font: inherit; font-size: 12px; cursor: pointer;
+}
+.action-button:hover, .remove-button:hover { background: var(--btn-hover, var(--hover)); }
+.remove-button { color: var(--vscode-errorForeground, #f14c4c); background: transparent; padding: 3px 7px; }
+.mmp-table { min-width: 820px; table-layout: fixed; }
+.mmp-table th:nth-child(1) { width: 42px; }
+.mmp-table th:nth-child(2), .mmp-table th:nth-child(3), .mmp-table th:nth-child(4) { width: 100px; }
+.mmp-table th:nth-child(5) { width: 180px; }
+.mmp-table th:nth-child(6) { width: 280px; }
+.mmp-table th:nth-child(7) { width: 84px; }
+.mmp-input { width: 100%; min-width: 0; height: 26px; padding: 3px 6px; color: var(--input-fg); background: var(--input-bg); border: 1px solid var(--input-border, var(--border)); border-radius: 2px; font: inherit; }
+.mmp-select { cursor: pointer; }
+.mmp-input:disabled, .color-input:disabled { opacity: 0.55; cursor: default; }
+.mmp-input:focus, .color-input:focus { outline: 1px solid var(--vscode-focusBorder, #007fd4); outline-offset: -1px; }
+.mmp-input.mono { font-family: var(--mono); }
+.color-cell { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; }
+.color-input { width: 34px; height: 26px; padding: 1px; border: 1px solid var(--input-border, var(--border)); background: var(--input-bg); border-radius: 2px; }
+.alpha-input { width: 68px; }
+.default-color { display: inline-flex; align-items: center; gap: 4px; color: var(--muted); font-size: 11px; white-space: nowrap; }
+.default-color input { margin: 0; accent-color: var(--vscode-checkbox-selectBackground, var(--vscode-button-background)); }
+.type-label { color: var(--muted); overflow-wrap: anywhere; }
+.row-number { vertical-align: middle; }
+.mmp-footer-hint { margin-top: 10px; }
+.dirty-badge[hidden] { display: none; }
+`;
+
+class MmpEditorProvider implements vscode.CustomEditorProvider<MmpDocument> {
+    private readonly _onDidChange = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<MmpDocument>>();
+    readonly onDidChangeCustomDocument = this._onDidChange.event;
+
+    async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext): Promise<MmpDocument> {
+        const source = openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri;
+        const doc = new MmpDocument(uri, parseMmpFile(Buffer.from(await vscode.workspace.fs.readFile(source))));
+        if (openContext.backupId) {
+            doc.currentRevision = 1;
+            doc.nextRevision = 2;
+        }
+        return doc;
+    }
+
+    async resolveCustomEditor(doc: MmpDocument, panel: vscode.WebviewPanel): Promise<void> {
+        panel.webview.options = { enableScripts: true, localResourceRoots: [] };
+        doc.webview = panel.webview;
+        panel.onDidDispose(() => { if (doc.webview === panel.webview) doc.webview = undefined; });
+        panel.webview.onDidReceiveMessage((message) => this.handleMessage(message, doc));
+        this.render(doc, panel.webview);
+    }
+
+    private render(doc: MmpDocument, webview: vscode.Webview): void {
+        const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);
+        webview.html = doc.file.error
+            ? buildPage({
+                csp: "default-src 'none'; style-src 'unsafe-inline';",
+                title: escapeHtml(fileName),
+                body: `<div class="wv-state"><span>Failed to parse MMP</span><span class="err">${escapeHtml(doc.file.error)}</span></div>`,
+            })
+            : renderMmpEditor(doc, fileName);
+    }
+
+    private handleMessage(message: unknown, doc: MmpDocument): void {
+        if (!message || typeof message !== 'object' || doc.file.error) return;
+        const msg = message as { type?: string; index?: number; field?: string; value?: string; on?: boolean };
+        if (msg.type === 'add') return this.addIcon(doc);
+        if (!this.isValidIconIndex(msg.index, doc)) return;
+        const index = msg.index as number;
+        if (msg.type === 'remove') return this.removeIcon(doc, index);
+        if (msg.type === 'defaultColor' && typeof msg.on === 'boolean') return this.editDefaultColor(doc, index, msg.on);
+        if (msg.type === 'edit' && typeof msg.field === 'string' && typeof msg.value === 'string') {
+            this.editField(doc, index, msg.field, msg.value);
+        }
+    }
+
+    private isValidIconIndex(index: number | undefined, doc: MmpDocument): index is number {
+        return Number.isInteger(index) && (index as number) >= 0 && (index as number) < doc.file.icons.length;
+    }
+
+    private addIcon(doc: MmpDocument): void {
+        const index = doc.file.icons.length;
+        const icon: MmpIcon = { type: 0, x: 0, y: 0, blue: 0xff, green: 0xff, red: 0xff, alpha: 0xff };
+        this.pushEdit(doc, 'Add minimap icon', {
+            apply: () => { doc.file.icons.push(icon); },
+            revert: () => { doc.file.icons.splice(index, 1); },
+        });
+    }
+
+    private removeIcon(doc: MmpDocument, index: number): void {
+        const removed = { ...doc.file.icons[index] };
+        this.pushEdit(doc, 'Remove minimap icon', {
+            apply: () => { doc.file.icons.splice(index, 1); },
+            revert: () => { doc.file.icons.splice(index, 0, removed); },
+        });
+    }
+
+    private editDefaultColor(doc: MmpDocument, index: number, on: boolean): void {
+        this.editIcon(doc, index, 'Set default icon color', (icon) => {
+            icon.blue = on ? 0xff : icon.blue;
+            icon.green = on ? 0xff : icon.green;
+            icon.red = on ? 0xff : icon.red;
+            icon.alpha = on ? 0xff : icon.alpha;
+        });
+    }
+
+    private editField(doc: MmpDocument, index: number, field: string, rawValue: string): void {
+        if (field === 'color') {
+            const color = parseMmpColor(rawValue);
+            if (color) this.editIcon(doc, index, 'Edit icon color', (icon) => Object.assign(icon, color));
+            return;
+        }
+        if (!['type', 'x', 'y', 'alpha'].includes(field)) return;
+        const value = Number(rawValue);
+        const valid = Number.isInteger(value) && (field !== 'alpha' || value >= 0 && value <= 0xff);
+        if (valid) this.editIcon(doc, index, `Edit icon ${field}`, (icon) => { icon[field as 'type' | 'x' | 'y' | 'alpha'] = value; });
+    }
+
+    private editIcon(doc: MmpDocument, index: number, label: string, mutate: (icon: MmpIcon) => void): void {
+        const before = { ...doc.file.icons[index] };
+        const after = { ...before };
+        mutate(after);
+        if (JSON.stringify(before) === JSON.stringify(after)) return;
+        this.pushEdit(doc, label, {
+            apply: () => { doc.file.icons[index] = { ...after }; },
+            revert: () => { doc.file.icons[index] = { ...before }; },
+        });
+    }
+
+    private pushEdit(doc: MmpDocument, label: string, edit: MmpEdit): void {
+        const beforeRevision = doc.currentRevision;
+        const afterRevision = doc.nextRevision++;
+        edit.apply();
+        doc.currentRevision = afterRevision;
+        this.postState(doc);
+        this._onDidChange.fire({
+            document: doc,
+            label,
+            undo: () => { edit.revert(); doc.currentRevision = beforeRevision; this.postState(doc); },
+            redo: () => { edit.apply(); doc.currentRevision = afterRevision; this.postState(doc); },
+        });
+    }
+
+    private postState(doc: MmpDocument): void {
+        void doc.webview?.postMessage({
+            type: 'mmpStateChanged',
+            listHtml: renderMmpList(doc.file),
+            count: doc.file.icons.length,
+            isDirty: doc.currentRevision !== doc.savedRevision,
+        });
+    }
+
+    async saveCustomDocument(doc: MmpDocument): Promise<void> {
+        try {
+            await this.writeMmp(doc, doc.uri);
+            doc.savedRevision = doc.currentRevision;
+            this.postState(doc);
+        } catch (err) {
+            void showErrorWithLogs(`Minimap icons not saved: ${err instanceof Error ? err.message : String(err)}`, err);
+            throw err;
+        }
+    }
+
+    async saveCustomDocumentAs(doc: MmpDocument, target: vscode.Uri): Promise<void> {
+        await vscode.workspace.fs.writeFile(target, serializeValidatedMmp(doc.file, target.path));
+    }
+
+    private async writeMmp(doc: MmpDocument, uri: vscode.Uri): Promise<void> {
+        const bytes = serializeValidatedMmp(doc.file, uri.path);
+        try {
+            const existing = Buffer.from(await vscode.workspace.fs.readFile(uri));
+            if (existing.equals(bytes)) return;
+        } catch { /* missing → write */ }
+        await vscode.workspace.fs.writeFile(uri, bytes);
+    }
+
+    async revertCustomDocument(doc: MmpDocument): Promise<void> {
+        doc.file = parseMmpFile(Buffer.from(await vscode.workspace.fs.readFile(doc.uri)));
+        doc.currentRevision = 0;
+        doc.savedRevision = 0;
+        doc.nextRevision = 1;
+        if (doc.webview) this.render(doc, doc.webview);
+    }
+
+    async backupCustomDocument(doc: MmpDocument, context: vscode.CustomDocumentBackupContext): Promise<vscode.CustomDocumentBackup> {
+        await vscode.workspace.fs.writeFile(context.destination, serializeValidatedMmp(doc.file, doc.uri.path));
+        return {
+            id: context.destination.toString(),
+            delete: () => vscode.workspace.fs.delete(context.destination).then(() => undefined, () => undefined),
+        };
+    }
+}
+
+function parseMmpColor(value: string): Pick<MmpIcon, 'red' | 'green' | 'blue'> | undefined {
+    if (!/^#[0-9a-f]{6}$/i.test(value)) return undefined;
+    return {
+        red: parseInt(value.slice(1, 3), 16),
+        green: parseInt(value.slice(3, 5), 16),
+        blue: parseInt(value.slice(5, 7), 16),
+    };
+}
+
+function serializeMmp(file: MmpFile): Buffer {
+    const w = new BinWriter(8 + file.icons.length * 16 + file.tail.length);
+    w.writeI32(file.version);
+    w.writeI32(file.icons.length);
+    for (const icon of file.icons) {
+        w.writeI32(icon.type);
+        w.writeI32(icon.x);
+        w.writeI32(icon.y);
+        w.writeU8(icon.blue);
+        w.writeU8(icon.green);
+        w.writeU8(icon.red);
+        w.writeU8(icon.alpha);
+    }
+    w.writeBytes(file.tail);
+    return w.toBuffer();
+}
+
+function serializeValidatedMmp(file: MmpFile, name: string): Buffer {
+    if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
+    const bytes = serializeMmp(file);
+    const reparsed = parseMmpFile(bytes);
+    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.icons.length !== file.icons.length ||
+        reparsed.icons.some((icon, index) => JSON.stringify(icon) !== JSON.stringify(file.icons[index]))) {
+        throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    }
+    return bytes;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1509,10 +2255,25 @@ export function registerMapDataPreview(_context: vscode.ExtensionContext): vscod
         render: renderMapData,
         webviewOptions: { enableScripts: true },
     });
+    const mmpEditor = vscode.window.registerCustomEditorProvider(
+        'wurst.mmpEditor',
+        new MmpEditorProvider(),
+        { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
+    );
+    const w3cEditor = vscode.window.registerCustomEditorProvider(
+        'wurst.w3cEditor',
+        new W3cEditorProvider(),
+        { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
+    );
+    const w3rEditor = vscode.window.registerCustomEditorProvider(
+        'wurst.w3rEditor',
+        new W3rEditorProvider(),
+        { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
+    );
     const w3iEditor = vscode.window.registerCustomEditorProvider(
         'wurst.w3iEditor',
         new W3iEditorProvider(),
         { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
     );
-    return vscode.Disposable.from(readonly, w3iEditor);
+    return vscode.Disposable.from(readonly, mmpEditor, w3cEditor, w3rEditor, w3iEditor);
 }

--- a/src/features/mapDataPreview.ts
+++ b/src/features/mapDataPreview.ts
@@ -1382,8 +1382,18 @@ function serializeW3c(file: W3cFile): Buffer {
 function serializeValidatedW3c(file: W3cFile, name: string): Buffer {
     if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
     const reparsed = parseW3cFile(serializeW3c(file));
-    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.cameras.length !== file.cameras.length || reparsed.cameras.some((camera, i) => JSON.stringify(camera) !== JSON.stringify(file.cameras[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    const expectedCameras = file.cameras.map(normalizeW3cCamera);
+    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.cameras.length !== expectedCameras.length || reparsed.cameras.some((camera, i) => JSON.stringify(camera) !== JSON.stringify(expectedCameras[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
     return serializeW3c(file);
+}
+
+function normalizeW3cCamera(camera: W3cCamera): W3cCamera {
+    return {
+        ...camera,
+        targetX: Math.fround(camera.targetX), targetY: Math.fround(camera.targetY), zOffset: Math.fround(camera.zOffset),
+        rotation: Math.fround(camera.rotation), angleOfAttack: Math.fround(camera.angleOfAttack), distance: Math.fround(camera.distance),
+        roll: Math.fround(camera.roll), fieldOfView: Math.fround(camera.fieldOfView), farZ: Math.fround(camera.farZ), unknown: Math.fround(camera.unknown),
+    };
 }
 
 const W3R_NUMERIC_FIELDS = new Set<keyof W3rRegion>(['minX', 'maxX', 'minY', 'maxY', 'index']);
@@ -1498,8 +1508,13 @@ function serializeW3r(file: W3rFile): Buffer {
 function serializeValidatedW3r(file: W3rFile, name: string): Buffer {
     if (file.error) throw new Error(`Refusing to save ${name}: the source file did not parse (${file.error}).`);
     const bytes = serializeW3r(file); const reparsed = parseW3rFile(bytes);
-    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.regions.length !== file.regions.length || reparsed.regions.some((region, i) => JSON.stringify(region) !== JSON.stringify(file.regions[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
+    const expectedRegions = file.regions.map(normalizeW3rRegion);
+    if (reparsed.error || reparsed.version !== file.version || !reparsed.tail.equals(file.tail) || reparsed.regions.length !== expectedRegions.length || reparsed.regions.some((region, i) => JSON.stringify(region) !== JSON.stringify(expectedRegions[i]))) throw new Error(`Refusing to save ${name}: round-trip verification failed.`);
     return bytes;
+}
+
+function normalizeW3rRegion(region: W3rRegion): W3rRegion {
+    return { ...region, minX: Math.fround(region.minX), maxX: Math.fround(region.maxX), minY: Math.fround(region.minY), maxY: Math.fround(region.maxY) };
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -2268,6 +2283,12 @@ export function registerMapDataPreview(_context: vscode.ExtensionContext): vscod
         render: renderMapData,
         webviewOptions: { enableScripts: true },
     });
+    const readonlyArchive = registerParsedPreviewer<MapDataFile>({
+        viewType: 'wurst.mapDataArchivePreview',
+        parse: parseMapData,
+        render: renderMapData,
+        webviewOptions: { enableScripts: true },
+    });
     const mmpEditor = vscode.window.registerCustomEditorProvider(
         'wurst.mmpEditor',
         new MmpEditorProvider(),
@@ -2288,5 +2309,5 @@ export function registerMapDataPreview(_context: vscode.ExtensionContext): vscod
         new W3iEditorProvider(),
         { supportsMultipleEditorsPerDocument: false, webviewOptions: { retainContextWhenHidden: true } },
     );
-    return vscode.Disposable.from(readonly, mmpEditor, w3cEditor, w3rEditor, w3iEditor);
+    return vscode.Disposable.from(readonly, readonlyArchive, mmpEditor, w3cEditor, w3rEditor, w3iEditor);
 }

--- a/src/features/mapDataPreview.ts
+++ b/src/features/mapDataPreview.ts
@@ -1135,6 +1135,10 @@ function fmt(value: number): string {
     return value.toFixed(3).replace(/\.?0+$/, '');
 }
 
+function fmtF32(value: number): string {
+    return Math.fround(value).toString();
+}
+
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -1227,7 +1231,7 @@ const W3C_NUMERIC_FIELDS = new Set<keyof W3cCamera>([
 ]);
 
 function w3cCameraInput(camera: W3cCamera, index: number, field: keyof W3cCamera, className = ''): string {
-    const value = field === 'name' ? camera.name : fmt(camera[field] as number);
+    const value = field === 'name' ? camera.name : fmtF32(camera[field] as number);
     const type = field === 'name' ? 'text' : 'number';
     const step = field === 'name' ? '' : ' step="any"';
     return `<input class="list-input ${className}" type="${type}"${step} data-index="${index}" data-field="${field}" value="${escapeHtml(value)}" aria-label="Camera ${index + 1} ${field}">`;
@@ -1399,7 +1403,7 @@ function normalizeW3cCamera(camera: W3cCamera): W3cCamera {
 const W3R_NUMERIC_FIELDS = new Set<keyof W3rRegion>(['minX', 'maxX', 'minY', 'maxY', 'index']);
 
 function w3rRegionInput(region: W3rRegion, index: number, field: keyof W3rRegion, className = ''): string {
-    const value = field === 'name' || field === 'weatherId' || field === 'sound' ? region[field] as string : fmt(region[field] as number);
+    const value = field === 'name' || field === 'weatherId' || field === 'sound' ? region[field] as string : fmtF32(region[field] as number);
     const type = field === 'name' || field === 'weatherId' || field === 'sound' ? 'text' : 'number';
     const step = type === 'number' && field !== 'index' ? ' step="any"' : '';
     const maxLength = field === 'weatherId' ? ' maxlength="4"' : '';

--- a/src/features/mpqViewer.ts
+++ b/src/features/mpqViewer.ts
@@ -51,9 +51,7 @@ function getPreviewViewType(fileName: string): string | undefined {
     if (ext === '.wpm') return 'wurst.wpmPreview';
     if (ext === '.wtg') return 'wurst.wtgPreview';
     if (ext === '.wct') return 'wurst.wctPreview';
-    if (ext === '.mmp') return 'wurst.mmpEditor';
-    if (ext === '.w3c') return 'wurst.w3cEditor';
-    if (ext === '.w3r') return 'wurst.w3rEditor';
+    if (['.mmp', '.w3c', '.w3r'].includes(ext)) return 'wurst.mapDataArchivePreview';
     if (['.imp', '.shd', '.w3i', '.w3e', '.w3s', '.w3l', '.w3o'].includes(ext)) return 'wurst.mapDataPreview';
     return undefined;
 }

--- a/src/features/mpqViewer.ts
+++ b/src/features/mpqViewer.ts
@@ -51,7 +51,10 @@ function getPreviewViewType(fileName: string): string | undefined {
     if (ext === '.wpm') return 'wurst.wpmPreview';
     if (ext === '.wtg') return 'wurst.wtgPreview';
     if (ext === '.wct') return 'wurst.wctPreview';
-    if (['.imp', '.mmp', '.shd', '.w3c', '.w3i', '.w3r', '.w3e', '.w3s', '.w3l', '.w3o'].includes(ext)) return 'wurst.mapDataPreview';
+    if (ext === '.mmp') return 'wurst.mmpEditor';
+    if (ext === '.w3c') return 'wurst.w3cEditor';
+    if (ext === '.w3r') return 'wurst.w3rEditor';
+    if (['.imp', '.shd', '.w3i', '.w3e', '.w3s', '.w3l', '.w3o'].includes(ext)) return 'wurst.mapDataPreview';
     return undefined;
 }
 


### PR DESCRIPTION
## Summary

- Add editable custom editors for Warcraft III `.mmp`, `.w3c`, and `.w3r` map metadata files.
- Support editing, adding, removing, undoing, redoing, and saving minimap icons, cameras, and regions.
- Preserve opaque binary tails and validate serialized data by reparsing before writes.
- Add fixtures and end-to-end coverage for the new editors.

## Checks

- `npm test`
- `npx tsc -p . --noEmit`
- `npm run lint`
- `npm run test:e2e` — 65 passed
- `git diff --check`

## Known gaps

- Camera and region string fields currently edit the stored raw strings directly; localized/TRIGSTR resolution remains outside this change.
