### PR TITLE
One texture pipeline for every model viewer, thumbnails by URI

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import { registerFileCreation } from './features/fileCreation';
 import { openIssueReport } from './features/issueReporting';
 import { registerCascDiagnosticsCommand, registerGameDataSettingsWatcher } from './features/preview/cascStorage';
 import { registerAssetRootInvalidation } from './features/imageAssetSupport';
+import { registerTextureCacheInvalidation } from './features/preview/modelPreviewHost';
 import { formatDiagnosticError, showErrorWithLogs, showWarningWithLogs } from './features/diagnostics';
 
 export async function activate(context: ExtensionContext) {
@@ -53,6 +54,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(registerCascDiagnosticsCommand());
     context.subscriptions.push(registerGameDataSettingsWatcher());
     context.subscriptions.push(registerAssetRootInvalidation());
+    context.subscriptions.push(registerTextureCacheInvalidation());
     registerWurstDiagnosticsCommands(context);
 
     registerBasicCommands(context);

--- a/src/features/assetLinks.ts
+++ b/src/features/assetLinks.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { gatherImportedAssets, getCandidateRoots, requestPreviewIcon, resolveAssetPath as resolveAssetPathString, resolveAssetPathWithCasc } from './imageAssetSupport';
 import { loadObjValueCatalog, type ValueOption } from './objModPreview';
 import { cacheModelThumbnail, markModelThumbnailBad, postTexturesToWebview, requestModelThumbnail } from './preview/modelPreviewHost';
+import { getGameAssetCacheDir, getModelThumbCacheDir } from './preview/cascStorage';
 import { isSoundAssetPath, playSoundInline } from './soundPreview';
 import { buildPage, ICON_INLINE_CSS, PREVIEW_ICON_CSP } from './webviewShared';
 import { escapeHtml } from './webviewUtils';
@@ -168,9 +169,10 @@ async function replaceAssetString(target: BrowseAssetTarget, assetPath: string):
 }
 
 async function openCodeAssetBrowser(context: vscode.ExtensionContext, target: BrowseAssetTarget): Promise<void> {
-    const [catalog, imported] = await Promise.all([
+    const [catalog, imported, assetRoots] = await Promise.all([
         loadObjValueCatalog(),
         gatherImportedAssets(target.uri.fsPath),
+        getCandidateRoots(target.uri.fsPath),
     ]);
     const panel = vscode.window.createWebviewPanel(
         'wurst.assetBrowser',
@@ -179,7 +181,15 @@ async function openCodeAssetBrowser(context: vscode.ExtensionContext, target: Br
         {
             enableScripts: true,
             retainContextWhenHidden: true,
-            localResourceRoots: [context.extensionUri, vscode.Uri.joinPath(context.extensionUri, 'dist', 'webview')],
+            // Asset roots + caches are admitted so models and cached thumbnails can be fetched by URI
+            // instead of travelling through postMessage as base64.
+            localResourceRoots: [
+                context.extensionUri,
+                vscode.Uri.joinPath(context.extensionUri, 'dist', 'webview'),
+                ...assetRoots.map((root) => vscode.Uri.file(root)),
+                vscode.Uri.file(getGameAssetCacheDir()),
+                vscode.Uri.file(getModelThumbCacheDir()),
+            ],
         },
     );
     const mdxViewerUri = panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'dist', 'webview', 'mdxViewer.js')).toString();
@@ -205,7 +215,7 @@ async function openCodeAssetBrowser(context: vscode.ExtensionContext, target: Br
         } else if (msg.type === 'loadObjectIcon' && typeof msg.iconPath === 'string' && typeof msg.key === 'string') {
             void requestPreviewIcon(msg.iconPath, msg.key, panel.webview, target.uri);
         } else if (msg.type === 'loadModelThumb' && typeof msg.path === 'string' && typeof msg.key === 'string') {
-            void requestModelThumbnail(msg.path, msg.key, target.uri, panel.webview);
+            void requestModelThumbnail(msg.path, msg.key, target.uri, panel.webview, true);
         } else if (msg.type === 'requestTextures' && Array.isArray(msg.paths)) {
             void postTexturesToWebview(
                 msg.paths.filter((candidate: unknown): candidate is string => typeof candidate === 'string'),

--- a/src/features/assetLinks.ts
+++ b/src/features/assetLinks.ts
@@ -484,8 +484,15 @@ ${ICON_INLINE_CSS}
     for (var i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
     return out.buffer;
   }
+  // The host sends either a webview resource URI (fetched here) or, for test doubles, base64 bytes.
   function loadModelBytes(job) {
-    return base64ToArrayBuffer(job.mdxBase64 || '');
+    if (job.modelUri) {
+      return fetch(job.modelUri).then(function (response) {
+        if (!response.ok) throw new Error('fetch ' + response.status);
+        return response.arrayBuffer();
+      });
+    }
+    return Promise.resolve(base64ToArrayBuffer(job.mdxBase64 || ''));
   }
   function renderModelThumb(job) {
     if (!ensureModelRenderer()) { markModelFailed(job.key, 'renderer-missing'); return; }
@@ -493,11 +500,16 @@ ${ICON_INLINE_CSS}
     modelJob.receivedTextures = new Set();
     modelJob.requestedTextures = null;
     modelJob.pendingTextures = new Set();
-    try {
-      mpvViewer().loadModel(loadModelBytes(job), job.fileName || '', job.format || 'mdx', { autoplay: false, textureCacheKey: 'thumbnail' });
-    } catch (e) {
-      markModelFailed(job.key, 'load-error');
-    }
+    loadModelBytes(job).then(function (bytes) {
+      if (modelJob !== job) return; // superseded while the bytes were in flight
+      try {
+        mpvViewer().loadModel(bytes, job.fileName || '', job.format || 'mdx', { autoplay: false, textureCacheKey: 'thumbnail' });
+      } catch (e) {
+        markModelFailed(job.key, 'load-error');
+      }
+    }, function () {
+      if (modelJob === job) markModelFailed(job.key, 'fetch-error');
+    });
   }
   function scheduleModelCapture(delayMs, frames) {
     if (!modelJob) return;

--- a/src/features/assetLinks.ts
+++ b/src/features/assetLinks.ts
@@ -7,7 +7,7 @@ import { loadObjValueCatalog, type ValueOption } from './objModPreview';
 import { cacheModelThumbnail, markModelThumbnailBad, postTexturesToWebview, requestModelThumbnail } from './preview/modelPreviewHost';
 import { getGameAssetCacheDir, getModelThumbCacheDir } from './preview/cascStorage';
 import { isSoundAssetPath, playSoundInline } from './soundPreview';
-import { buildPage, ICON_INLINE_CSS, PREVIEW_ICON_CSP } from './webviewShared';
+import { buildPage, ICON_INLINE_CSS } from './webviewShared';
 import { escapeHtml } from './webviewUtils';
 import { showWarningWithLogs } from './diagnostics';
 import { assetSearchScore, fuzzyMatch } from './preview/fuzzy';
@@ -245,7 +245,10 @@ function dedupeAssetOptions(options: readonly ValueOption[]): ValueOption[] {
 
 function buildAssetBrowserHtml(initialJson: string, currentValue: string, cspSource: string, mdxViewerUri: string): string {
     return buildPage({
-        csp: PREVIEW_ICON_CSP.replace("script-src 'unsafe-inline';", `script-src 'unsafe-inline' ${cspSource};`),
+        // Models and cached thumbnails are fetched/displayed as webview resource URIs (see
+        // requestModelThumbnail with useModelUri), so the extension's cspSource must be admitted for
+        // connect-src and img-src, not only script-src.
+        csp: `default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline' ${cspSource}; img-src data: ${cspSource}; connect-src ${cspSource};`,
         title: 'Choose Warcraft III Asset',
         extraCss: `
 ${ICON_INLINE_CSS}

--- a/src/features/blpPreview.ts
+++ b/src/features/blpPreview.ts
@@ -12,7 +12,7 @@ import {
     findGameAsset,
 } from './preview/cascStorage';
 import { DecodedBlpImage, decodeRasterPreview } from './preview/imageDecoders';
-import { postTexturesToWebview } from './preview/modelPreviewHost';
+import { clearTextureMissCache, postTexturesToWebview } from './preview/modelPreviewHost';
 
 // Re-exported for backwards-compat with existing callers that import from blpPreview.
 export { decodeRasterPreview, decodeToRgba } from './preview/imageDecoders';
@@ -201,7 +201,8 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
             const watcher = vscode.workspace.createFileSystemWatcher(
                 new vscode.RelativePattern(path.dirname(filePath), path.basename(filePath))
             );
-            const rerender = () => { cachedBytes = undefined; requestRender(); };
+            // The file changed on disk; textures that were missing may have arrived with it.
+            const rerender = () => { cachedBytes = undefined; clearTextureMissCache(); requestRender(); };
             watcher.onDidChange(rerender);
             watcher.onDidCreate(rerender);
             webviewPanel.onDidDispose(() => watcher.dispose());
@@ -224,6 +225,7 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
             if (type === 'refresh') {
                 dbg(`refresh requested`);
                 cachedBytes = undefined;
+                clearTextureMissCache();
                 requestRender();
                 return;
             }

--- a/src/features/blpPreview.ts
+++ b/src/features/blpPreview.ts
@@ -10,14 +10,9 @@ import {
     getGameAssetCacheDir,
     findGameTexture,
     findGameAsset,
-    findLocalTexture,
 } from './preview/cascStorage';
-import {
-    DecodedBlpImage,
-    decodeRasterPreview,
-    decodeDds,
-    decodeTga,
-} from './preview/imageDecoders';
+import { DecodedBlpImage, decodeRasterPreview } from './preview/imageDecoders';
+import { postTexturesToWebview } from './preview/modelPreviewHost';
 
 // Re-exported for backwards-compat with existing callers that import from blpPreview.
 export { decodeRasterPreview, decodeToRgba } from './preview/imageDecoders';
@@ -243,72 +238,10 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
                 const rawPaths = (msg as { paths?: unknown }).paths;
                 if (!Array.isArray(rawPaths)) return;
                 const texPaths: string[] = rawPaths.filter((p): p is string => typeof p === 'string');
-                const mdxFsPath = document.uri.scheme === 'file' ? document.uri.fsPath : '';
                 dbg(`texture request: ${texPaths.length} paths`);
-
-                // Resolve textures concurrently
-                // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO(lint-cleanup): pre-existing, tracked for a dedicated decomposition pass rather than a rushed refactor here.
-                await Promise.all(texPaths.map(async (texPath) => {
-                    try {
-                        let texBuf: Buffer | null = null;
-                        let texExt: 'blp' | 'dds' | 'tga' | null = null;
-                        let resolvedFsPath: string | null = null;
-
-                        // 1. Local file lookup (also tries .dds for .blp references)
-                        if (mdxFsPath) {
-                            const found = findLocalTexture(texPath, mdxFsPath);
-                            if (found) {
-                                texBuf = found.buf;
-                                const localExt = path.extname(found.foundPath).toLowerCase();
-                                if (localExt === '.dds') texExt = 'dds';
-                                else if (localExt === '.tga') texExt = 'tga';
-                                else texExt = 'blp';
-                                resolvedFsPath = found.foundPath;
-                            }
-                        }
-
-                        // 2. CASC local archive fallback (uses wurst.wc3path)
-                        if (!texBuf) {
-                            const casc = await findGameTexture(texPath, dbg);
-                            if (casc) {
-                                texBuf = casc.buf;
-                                texExt = casc.ext;
-                                // Reconstruct the cache path so the webview can offer an "open" link
-                                const cacheDir = getGameAssetCacheDir();
-                                const normalized = texPath.replace(/\//g, '\\').toLowerCase();
-                                const base = normalized.replace(/\.[^\\.]+$/, '');
-                                const rel = `${base}.${texExt}`;
-                                // ':' (CASC namespaces like "_hd.w3mod:") is illegal in Windows paths — mirror getCachedAssetPath.
-                                resolvedFsPath = path.join(cacheDir, ...rel.replace(/:/g, '$').split('\\'));
-                            }
-                        }
-
-                        if (!texBuf || !texExt) {
-                            await webviewPanel.webview.postMessage({ type: 'texture', path: texPath, resolvedFsPath: null, blpBase64: null });
-                            dbg(`texture ${texPath}: not found`);
-                            return;
-                        }
-
-                        if (texExt === 'dds' || texExt === 'tga') {
-                            const decoded = texExt === 'dds' ? decodeDds(new Uint8Array(texBuf)) : decodeTga(new Uint8Array(texBuf));
-                            if (decoded.mode === 'rgba') {
-                                await webviewPanel.webview.postMessage({
-                                    type: 'texture', path: texPath, resolvedFsPath,
-                                    blpBase64: null, rgbaBase64: decoded.rgbaBase64,
-                                    width: decoded.width, height: decoded.height,
-                                });
-                            } else {
-                                await webviewPanel.webview.postMessage({ type: 'texture', path: texPath, resolvedFsPath, blpBase64: null });
-                            }
-                        } else {
-                            await webviewPanel.webview.postMessage({ type: 'texture', path: texPath, resolvedFsPath, blpBase64: texBuf.toString('base64') });
-                        }
-                        dbg(`texture ${texPath}: found (${texExt})`);
-                    } catch (e) {
-                        dbg(`texture error ${texPath}: ${String(e)}`);
-                        await webviewPanel.webview.postMessage({ type: 'texture', path: texPath, resolvedFsPath: null, blpBase64: null });
-                    }
-                }));
+                // Same resolver, payload cache and concurrency limit as the object editor's inline
+                // model preview and the asset browser — this viewer used to carry its own copy.
+                await postTexturesToWebview(texPaths, document.uri, webviewPanel.webview);
                 return;
             }
             if (type === 'openTexture') {
@@ -978,7 +911,7 @@ class BlpPreviewProvider implements vscode.CustomReadonlyEditorProvider<BlpDocum
         if (w3v) w3v.loadModel(base64ToArrayBuffer(msg.mdxBase64), msg.fileName || '', msg.format || 'mdx');
         return;
       }
-      if (msg.type === 'texture') {
+      if (msg.type === 'mdxTexture') {
         if (w3v) {
           if (msg.ddsBase64) {
             w3v.onTextureDds(msg.path, base64ToArrayBuffer(msg.ddsBase64));

--- a/src/features/imageAssetSupport.ts
+++ b/src/features/imageAssetSupport.ts
@@ -181,18 +181,30 @@ export function registerAssetRootInvalidation(): vscode.Disposable {
     );
 }
 
-export async function getCandidateRoots(documentFsPath: string): Promise<string[]> {
+export interface CandidateRootOptions {
+    /**
+     * Also treat up to four ancestor directories of the document as roots. Model files reference
+     * textures relative to their map/project root, which is often a parent of the model's folder
+     * without being a workspace folder itself. Only for lookups, not for scans: `gatherImportedAssets`
+     * must never walk a home directory.
+     */
+    includeAncestors?: boolean;
+}
+
+const ANCESTOR_ROOT_LEVELS = 4;
+
+export async function getCandidateRoots(documentFsPath: string, options: CandidateRootOptions = {}): Promise<string[]> {
     const workspaceKey = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri.fsPath).join('|');
-    const cacheKey = `${documentFsPath}|${workspaceKey}`;
+    const cacheKey = `${documentFsPath}|${options.includeAncestors ? 'ancestors' : ''}|${workspaceKey}`;
     let promise = candidateRootsCache.get(cacheKey);
     if (!promise) {
-        promise = getCandidateRootsUncached(documentFsPath);
+        promise = getCandidateRootsUncached(documentFsPath, options);
         candidateRootsCache.set(cacheKey, promise);
     }
     return [...await promise];
 }
 
-async function getCandidateRootsUncached(documentFsPath: string): Promise<string[]> {
+async function getCandidateRootsUncached(documentFsPath: string, options: CandidateRootOptions): Promise<string[]> {
     const seen = new Set<string>();
     const roots: string[] = [];
     const add = (candidate: string) => {
@@ -215,6 +227,15 @@ async function getCandidateRootsUncached(documentFsPath: string): Promise<string
     add(documentDir);
     if (/\.(w3x|w3m)$/i.test(documentDir)) {
         addAssetSubdirs(documentDir);
+    }
+    if (options.includeAncestors) {
+        let dir = documentDir;
+        for (let level = 0; level < ANCESTOR_ROOT_LEVELS; level++) {
+            const parent = path.dirname(dir);
+            if (parent === dir) break;
+            add(parent);
+            dir = parent;
+        }
     }
 
     await Promise.all((vscode.workspace.workspaceFolders ?? []).map(async (folder) => {

--- a/src/features/objModPreview.ts
+++ b/src/features/objModPreview.ts
@@ -9,6 +9,7 @@ import { parseObjMod, serializeObjMod, ObjModFile, ObjModEntry, ObjModMod, ObjMo
 import { ParsedPreviewContext } from './preview/framework';
 import { requestPreviewIcon, requestTooltipBackdrop, requestTooltipBorder, getCandidateRoots, resolveAssetPathWithCasc, gatherImportedAssets } from './imageAssetSupport';
 import {
+    clearTextureMissCache,
     postModelToWebview,
     postTexturesToWebview,
     requestModelThumbnail,
@@ -3865,6 +3866,7 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
             return;
         }
         if (msg.type === 'refresh') {
+            clearTextureMissCache();
             await this.refreshFromDisk(doc);
             return;
         }

--- a/src/features/objModPreview.ts
+++ b/src/features/objModPreview.ts
@@ -30,7 +30,7 @@ import {
     UNIT_PROFILE_PATHS, ABILITY_PROFILE_PATHS, UPGRADE_PROFILE_PATHS,
     ITEM_PROFILE_PATHS, DESTRUCTABLE_PROFILE_PATHS, DOODAD_PROFILE_PATHS,
 } from './preview/wc3Data';
-import { getGameAssetCacheDir, listGameAssetPaths } from './preview/cascStorage';
+import { getGameAssetCacheDir, getModelThumbCacheDir, listGameAssetPaths } from './preview/cascStorage';
 import { showErrorWithLogs, showWarningWithLogs } from './diagnostics';
 import { repairTooltipTrueTypeFont } from './preview/tooltipFont';
 import {
@@ -3712,6 +3712,7 @@ class ObjModEditorProvider implements vscode.CustomEditorProvider<ObjModDocument
                 vscode.Uri.file(path.dirname(doc.uri.fsPath)),
                 vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview'),
                 vscode.Uri.file(getGameAssetCacheDir()),
+                vscode.Uri.file(getModelThumbCacheDir()),
             ],
         };
         const fileName = doc.uri.path.slice(doc.uri.path.lastIndexOf('/') + 1);

--- a/src/features/preview/cascStorage.ts
+++ b/src/features/preview/cascStorage.ts
@@ -863,32 +863,6 @@ export function logGameData(message: string): void {
     defaultCascLog(message);
 }
 
-/** Try to read a texture file from the local filesystem relative to the MDX file.
- *  Returns the buffer and the actual path found (may differ in extension). */
-export function findLocalTexture(texPath: string, mdxFsPath: string): { buf: Buffer; foundPath: string } | null {
-    const normalized = texPath.replace(/\\/g, '/');
-    // When the model references a .blp, also try the Reforged .dds equivalent.
-    const alternates = [normalized];
-    if (normalized.toLowerCase().endsWith('.blp')) {
-        alternates.push(normalized.slice(0, -4) + '.dds');
-    }
-    const mdxDir = path.dirname(mdxFsPath);
-
-    let dir = mdxDir;
-    for (let i = 0; i < 4; i++) {
-        for (const alt of alternates) {
-            const candidate = path.join(dir, alt);
-            if (fs.existsSync(candidate)) {
-                return { buf: fs.readFileSync(candidate), foundPath: candidate };
-            }
-        }
-        const parent = path.dirname(dir);
-        if (parent === dir) break;
-        dir = parent;
-    }
-    return null;
-}
-
 /**
  * Ensures a texture asset is present in the CASC disk cache, extracting from
  * the WC3 game files if needed.

--- a/src/features/preview/modelPreviewHost.ts
+++ b/src/features/preview/modelPreviewHost.ts
@@ -23,11 +23,22 @@ function extOf(p: string): string {
     return dot > slash ? p.slice(dot + 1).toLowerCase() : '';
 }
 
-async function readCachedThumb(cacheKey: string): Promise<{ uri: string; cachePath: string; bytes: number; buf: Buffer } | undefined> {
+/**
+ * Cached thumbnails are handed to the webview as `vscode-webview` resource URIs (the thumb cache dir
+ * is in every consumer's `localResourceRoots`), so the bytes never travel through postMessage as
+ * base64 and the webview does not keep a data URL per thumbnail alive. Falls back to a data URL for
+ * webviews without `asWebviewUri` (test doubles).
+ */
+function thumbUri(webview: vscode.Webview, cachePath: string, bytes: Buffer): string {
+    if (typeof webview.asWebviewUri !== 'function') return `data:image/webp;base64,${bytes.toString('base64')}`;
+    return webview.asWebviewUri(vscode.Uri.file(cachePath)).toString();
+}
+
+async function readCachedThumb(webview: vscode.Webview, cacheKey: string): Promise<{ uri: string; cachePath: string; bytes: number } | undefined> {
     const cachePath = path.join(getModelThumbCacheDir(), `${cacheKey}.webp`);
     try {
         const buf = await fs.promises.readFile(cachePath);
-        return { uri: `data:image/webp;base64,${buf.toString('base64')}`, cachePath, bytes: buf.length, buf };
+        return { uri: thumbUri(webview, cachePath, buf), cachePath, bytes: buf.length };
     } catch {
         return undefined;
     }
@@ -411,7 +422,7 @@ export async function requestModelThumbnail(
             diagnostic.modelBytes = stat.size;
         }
         const aliasKey = statThumbKey(resolved, stat);
-        const statCached = modelThumbCacheDisabled() ? undefined : await readCachedThumb(aliasKey);
+        const statCached = modelThumbCacheDisabled() ? undefined : await readCachedThumb(webview, aliasKey);
         const tStatCache = Date.now();
         if (statCached) {
             thumbLog(`${key} cache-hit-stat aliasKey=${aliasKey} path="${statCached.cachePath}" bytes=${statCached.bytes} roots=${tRoots - t0}ms resolve=${tResolved - tRoots}ms stat/cacheRead=${tStatCache - tStatStart}ms total=${tStatCache - t0}ms`);
@@ -497,7 +508,7 @@ export async function cacheModelThumbnail(key: string, cacheKey: string, webpBas
         const tWrite = Date.now();
         const aliasKeySuffix = aliasKey ? ` aliasKey=${aliasKey}` : '';
         thumbLog(`${key} cache-write key=${cacheKey}${aliasKeySuffix} path="${cachePath}" bytes=${bytes.length} decode=${tDecode - t0}ms mkdir=${tMkdir - tDecode}ms write=${tWrite - tMkdir}ms total=${tWrite - t0}ms`);
-        await webview.postMessage({ type: 'modelThumbLoaded', key, uri: `data:image/webp;base64,${bytes.toString('base64')}`, cacheKey });
+        await webview.postMessage({ type: 'modelThumbLoaded', key, uri: thumbUri(webview, cachePath, bytes), cacheKey });
     } catch (err) {
         thumbLog(`${key} cache-write error key=${cacheKey} total=${Date.now() - t0}ms error=${err instanceof Error ? err.message : String(err)}`);
         await webview.postMessage({ type: 'modelThumbMissing', key });
@@ -579,7 +590,7 @@ export async function postTexturesToWebview(
                 texturePayloadCache.set(cacheKey, cachedPayload);
                 stats.payloadCache++;
                 stats.sent++;
-                await post({ type: 'mdxTexture', path: texPath, ...cachedPayload });
+                await post({ type: 'mdxTexture', path: texPath, resolvedFsPath: resolved, ...cachedPayload });
                 return;
             }
             const bytes = Buffer.from(await vscode.workspace.fs.readFile(vscode.Uri.file(resolved)));
@@ -595,7 +606,7 @@ export async function postTexturesToWebview(
             rememberTexturePayload(cacheKey, built.payload);
             if (built.decodedDds) stats.decodedDds++;
             stats.sent++;
-            await post({ type: 'mdxTexture', path: texPath, ...built.payload });
+            await post({ type: 'mdxTexture', path: texPath, resolvedFsPath: resolved, ...built.payload });
         } catch {
             rememberMissingTexture(missKey);
             stats.errors++;

--- a/src/features/preview/modelPreviewHost.ts
+++ b/src/features/preview/modelPreviewHost.ts
@@ -546,7 +546,9 @@ export async function postTexturesToWebview(
     };
     let roots: string[];
     try {
-        roots = await getCandidateRoots(documentUri.fsPath);
+        // Models reference textures relative to their map/project root, which may be an ancestor of
+        // the model's folder rather than a workspace folder (the standalone viewer relied on this).
+        roots = await getCandidateRoots(documentUri.fsPath, { includeAncestors: true });
     } catch (err) {
         stats.errors = uniqueTexPaths.length;
         await forEachLimited(uniqueTexPaths, TEXTURE_RESOLVE_CONCURRENCY, async (texPath) => {

--- a/src/features/preview/modelPreviewHost.ts
+++ b/src/features/preview/modelPreviewHost.ts
@@ -194,6 +194,22 @@ function rememberTexturePayload(key: string, payload: TexturePayload): void {
     }
 }
 
+/**
+ * Forget every recorded texture miss. Misses are cached process-wide so a model with an absent
+ * texture does not re-probe the filesystem and CASC on every render; that cache has to be dropped
+ * when the world may have changed: an explicit Refresh/reload in a viewer, or a new WC3 game path.
+ */
+export function clearTextureMissCache(): void {
+    textureMissingCache.clear();
+}
+
+/** Drops cached texture misses when `wurst.wc3path` changes (the game data behind them moved). */
+export function registerTextureCacheInvalidation(): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration('wurst.wc3path')) clearTextureMissCache();
+    });
+}
+
 function rememberMissingTexture(key: string): void {
     if (textureMissingCache.has(key)) {
         textureMissingCache.delete(key);


### PR DESCRIPTION
## Summary

Stacked on #111. Third slice of the audit list: the duplicated texture pipeline and the base64 thumbnail transport.

### Texture pipeline
- The standalone model viewer (`blpPreview.ts`) resolves textures through `postTexturesToWebview`, the same code path as the object editor's inline preview and the asset browser: local-first resolver, payload and missing caches, and a concurrency limit of 6, replacing its own lookup with an unbounded `Promise.all`.
- Texture messages carry `resolvedFsPath` so the viewer's "open texture" link keeps working.
- The BLP-only `findLocalTexture` helper is removed. Behaviour difference: the old helper also walked up to four parent directories of the model file; the shared resolver uses the document folder, `imports/`-style subfolders, workspace roots and the game cache. For models inside a map folder or workspace this is a superset; for a lone model in an unrelated directory tree with textures in a grandparent folder it is not.

### Thumbnail transport
- Cached thumbnails are sent as `vscode-webview` resource URIs instead of base64 data URLs; `~/.wurst/model_thumbs` is in `localResourceRoots` for the object editor and the asset browser. Test doubles without `asWebviewUri` still get a data URL.
- The asset browser fetches model bytes by URI (as the object editor already did), so neither model nor thumbnail bytes travel through `postMessage` as base64 any more.

## Validation
- `tsc` (real siblings and CI mocks), `npm run lint`, `npm test`: clean.
- `npm run test:e2e`: all map-data editor specs pass; object-editor failures match the `master` baseline apart from the two known flaky specs, which pass on rerun.